### PR TITLE
Replace mock object with higher order function

### DIFF
--- a/src/Hodor/Command/Arguments.php
+++ b/src/Hodor/Command/Arguments.php
@@ -7,6 +7,11 @@ use Exception;
 class Arguments
 {
     /**
+     * @var callable
+     */
+    private $cli_opts_loader;
+
+    /**
      * @var array
      */
     private $loaded_arguments = [];
@@ -62,7 +67,8 @@ class Arguments
             return;
         }
 
-        $args = $this->getCliOpts();
+        $args_loader = $this->getCliOptsLoader();
+        $args = $args_loader();
 
         $this->processArgument($args, 'config', 'c');
         $this->processArgument($args, 'queue', 'q');
@@ -70,21 +76,34 @@ class Arguments
     }
 
     /**
-     * This method is defined as protected so the test suite
-     * can override the method with a mock.
-     *
-     * @return array
+     * @param callable $cli_opts_loader
      */
-    protected function getCliOpts()
+    public function setCliOptsLoader(callable $cli_opts_loader)
     {
-        return getopt(
-            'c:q:',
-            [
-                'config:',
-                'queue:',
-                'json',
-            ]
-        );
+        $this->cli_opts_loader = $cli_opts_loader;
+    }
+
+    /**
+     * @return callable
+     */
+    private function getCliOptsLoader()
+    {
+        if ($this->cli_opts_loader) {
+            return $this->cli_opts_loader;
+        }
+
+        $this->cli_opts_loader = function () {
+            return getopt(
+                'c:q:',
+                [
+                    'config:',
+                    'queue:',
+                    'json',
+                ]
+            );
+        };
+
+        return $this->cli_opts_loader;
     }
 
     /**

--- a/tests/src/Hodor/Command/ArgumentsTest.php
+++ b/tests/src/Hodor/Command/ArgumentsTest.php
@@ -12,7 +12,7 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
      */
     public function testRetrievingConfigWhenNotProvidedThrowsAnException()
     {
-        $arguments = $this->getMockedArguments([]);
+        $arguments = $this->getArgumentsObject([]);
 
         $arguments->getConfigFile();
     }
@@ -22,7 +22,7 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
      */
     public function testRetrievingConfigWhenBlankThrowsAnException()
     {
-        $arguments = $this->getMockedArguments([
+        $arguments = $this->getArgumentsObject([
             'config' => null,
         ]);
 
@@ -32,7 +32,7 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
     public function testRetrievingConfigWhenProvidedWithLongOpt()
     {
         $config_path = 'config.php';
-        $arguments = $this->getMockedArguments([
+        $arguments = $this->getArgumentsObject([
             'config' => $config_path,
         ]);
 
@@ -45,7 +45,7 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
     public function testRetrievingConfigWhenProvidedWithShortOpt()
     {
         $config_path = 'config.php';
-        $arguments = $this->getMockedArguments([
+        $arguments = $this->getArgumentsObject([
             'c' => $config_path,
         ]);
 
@@ -59,7 +59,7 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
      */
     public function testRetrievingQueueNameWhenNotProvidedThrowsAnException()
     {
-        $arguments = $this->getMockedArguments([]);
+        $arguments = $this->getArgumentsObject([]);
 
         $arguments->getQueueName();
     }
@@ -69,7 +69,7 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
      */
     public function testRetrievingQueueNameWhenBlankThrowsAnException()
     {
-        $arguments = $this->getMockedArguments([
+        $arguments = $this->getArgumentsObject([
             'queue' => null,
         ]);
 
@@ -79,7 +79,7 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
     public function testRetrievingQueueNameWhenProvidedWithLongOpt()
     {
         $queue_name = uniqid();
-        $arguments = $this->getMockedArguments([
+        $arguments = $this->getArgumentsObject([
             'queue' => $queue_name,
         ]);
 
@@ -92,7 +92,7 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
     public function testRetrievingQueueNameWhenProvidedWithShortOpt()
     {
         $queue_name = uniqid();
-        $arguments = $this->getMockedArguments([
+        $arguments = $this->getArgumentsObject([
             'q' => $queue_name,
         ]);
 
@@ -104,7 +104,7 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testRetrievingIsJsonWhenProvided()
     {
-        $arguments = $this->getMockedArguments([
+        $arguments = $this->getArgumentsObject([
             'json' => false,
         ]);
 
@@ -115,7 +115,7 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testRetrievingIsJsonWhenNotProvided()
     {
-        $arguments = $this->getMockedArguments([]);
+        $arguments = $this->getArgumentsObject([]);
 
         $this->assertFalse(
             $arguments->isJson()
@@ -126,7 +126,7 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
     {
         $config_path = 'config2.php';
         $queue_name = uniqid();
-        $arguments = $this->getMockedArguments([
+        $arguments = $this->getArgumentsObject([
             'config' => $config_path,
             'queue'  => $queue_name,
             'json'   => false,
@@ -149,14 +149,12 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
      * @param array $return_value
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    private function getMockedArguments(array $return_value)
+    private function getArgumentsObject(array $return_value)
     {
-        $arguments = $this->getMockBuilder('\Hodor\Command\Arguments')
-            ->setMethods(['getCliOpts'])
-            ->getMock();
-        $arguments->expects($this->once())
-            ->method('getCliOpts')
-            ->will($this->returnValue($return_value));
+        $arguments = new Arguments();
+        $arguments->setCliOptsLoader(function () use ($return_value) {
+            return $return_value;
+        });
 
         return $arguments;
     }


### PR DESCRIPTION
Mocks seem like they might be code smells. This code smell would be brought to you by PHP and `getopt` :wink:
