### PR TITLE
Set error_reporting to E_ALL when running tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,4 +31,7 @@
         <log type="testdox-html" target="tests/log/testdox.html"/>
         <log type="coverage-clover" target="tests/log/coverage.xml" />
     </logging>
+    <php>
+        <ini name="error_reporting" value="E_ALL" />
+    </php>
 </phpunit>


### PR DESCRIPTION
E_ALL should be on in the dev environment, but in case
it is not, force it when running tests
