### PR TITLE
Implement a basic superqueue

### DIFF
--- a/bin/superqueuer.php
+++ b/bin/superqueuer.php
@@ -14,4 +14,6 @@ $config = Config::loadFromFile($config_file);
 $queue_factory = new QueueFactory($config);
 $superqueue = $queue_factory->getSuperqueue();
 
-$superqueue->queueJobsFromDatabaseToWorkerQueue();
+if (!$superqueue->queueJobsFromDatabaseToWorkerQueue()) {
+    sleep(2);
+}

--- a/bin/superqueuer.php
+++ b/bin/superqueuer.php
@@ -2,3 +2,16 @@
 <?php
 
 require_once __DIR__ . '/../bootstrap.php';
+
+use Hodor\Command\Arguments as Arguments;
+use Hodor\Config\LoaderFacade as Config;
+use Hodor\JobQueue\QueueFactory as QueueFactory;
+
+$args = new Arguments();
+$config_file = $args->getConfigFile();
+
+$config = Config::loadFromFile($config_file);
+$queue_factory = new QueueFactory($config);
+$superqueue = $queue_factory->getSuperqueue();
+
+$superqueue->queueJobsFromDatabaseToWorkerQueue();

--- a/bin/superqueuer.php
+++ b/bin/superqueuer.php
@@ -14,6 +14,10 @@ $config = Config::loadFromFile($config_file);
 $queue_factory = new QueueFactory($config);
 $superqueue = $queue_factory->getSuperqueue();
 
+if (!$superqueue->requestProcessLock()) {
+    sleep(5);
+}
+
 if (!$superqueue->queueJobsFromDatabaseToWorkerQueue()) {
     sleep(2);
 }

--- a/config/dist/config.dist.php
+++ b/config/dist/config.dist.php
@@ -1,6 +1,6 @@
 <?php
 return [
-    'superqueuer' => [
+    'superqueue' => [
         'database' => [
             'type'     => 'pgsql',
             'dsn'      => 'pgsql:host=localhost;dbname=hodor',

--- a/src/Hodor/Database/AdapterInterface.php
+++ b/src/Hodor/Database/AdapterInterface.php
@@ -18,4 +18,11 @@ interface AdapterInterface
     public function beginTransaction();
     public function commitTransaction();
     public function rollbackTransaction();
+
+    /**
+     * @param $category
+     * @param $name
+     * @return bool
+     */
+    public function requestAdvisoryLock($category, $name);
 }

--- a/src/Hodor/Database/AdapterInterface.php
+++ b/src/Hodor/Database/AdapterInterface.php
@@ -6,9 +6,9 @@ interface AdapterInterface
 {
     public function bufferJob($queue_name, array $job);
 
-    public function getJobsToRun();
+    public function getJobsToRunGenerator();
 
-    public function markJobAsStarted($job);
+    public function markJobAsQueued(array $job);
 
     public function markJobAsCompleted($job);
     public function markJobAsFailed($job);

--- a/src/Hodor/Database/AdapterInterface.php
+++ b/src/Hodor/Database/AdapterInterface.php
@@ -4,7 +4,7 @@ namespace Hodor\Database;
 
 interface AdapterInterface
 {
-    public function createJob($job);
+    public function bufferJob($queue_name, array $job);
 
     public function getJobsToRun();
 

--- a/src/Hodor/Database/AdapterInterface.php
+++ b/src/Hodor/Database/AdapterInterface.php
@@ -10,8 +10,8 @@ interface AdapterInterface
 
     public function markJobAsQueued(array $job);
 
-    public function markJobAsCompleted($job);
-    public function markJobAsFailed($job);
+    public function markJobAsSuccessful(array $meta);
+    public function markJobAsFailed(array $meta);
 
     public function getPhpmigAdapter();
 

--- a/src/Hodor/Database/PgsqlAdapter.php
+++ b/src/Hodor/Database/PgsqlAdapter.php
@@ -27,8 +27,26 @@ class PgsqlAdapter implements AdapterInterface
         $this->config = $config;
     }
 
-    public function createJob($job)
+    /**
+     * @param string $queue_name
+     * @param array $job
+     */
+    public function bufferJob($queue_name, array $job)
     {
+        $row = [
+            'queue_name'    => $queue_name,
+            'job_name'      => $job['name'],
+            'job_params'    => json_encode($job['params']),
+            'buffered_at'   => $job['meta']['buffered_at'],
+            'buffered_from' => $job['meta']['buffered_from'],
+            'inserted_from' => gethostname(),
+        ];
+
+        if (isset($job['run_after'])) {
+            $row['run_after'] = $job['run_after'];
+        }
+
+        $this->getDriver()->insert('buffered_jobs', $row);
     }
 
     public function getJobsToRun()

--- a/src/Hodor/Database/PgsqlAdapter.php
+++ b/src/Hodor/Database/PgsqlAdapter.php
@@ -115,14 +115,17 @@ SQL;
 
     public function beginTransaction()
     {
+        $this->queryMultiple('BEGIN');
     }
 
     public function commitTransaction()
     {
+        $this->queryMultiple('COMMIT');
     }
 
     public function rollbackTransaction()
     {
+        $this->queryMultiple('ROLLBACK');
     }
 
     /**

--- a/src/Hodor/Database/PgsqlAdapter.php
+++ b/src/Hodor/Database/PgsqlAdapter.php
@@ -129,6 +129,27 @@ SQL;
     }
 
     /**
+     * @param $category
+     * @param $name
+     * @return bool
+     */
+    public function requestAdvisoryLock($category, $name)
+    {
+        $category_crc = crc32($category) - 0x80000000;
+        $name_crc = crc32($name) - 0x80000000;
+
+        $row = $this->getDriver()->selectOne(
+            'SELECT pg_try_advisory_lock(:category_crc, :name_crc) AS is_granted',
+            [
+                'category_crc' => $category_crc,
+                'name_crc'     => $name_crc,
+            ]
+        );
+
+        return $row['is_granted'];
+    }
+
+    /**
      * @param string $sql
      * @return void
      */

--- a/src/Hodor/Database/PgsqlAdapter.php
+++ b/src/Hodor/Database/PgsqlAdapter.php
@@ -74,6 +74,7 @@ SQL;
 
     /**
      * @param array $job
+     * @return array
      */
     public function markJobAsQueued(array $job)
     {
@@ -87,6 +88,8 @@ SQL;
             'queued_jobs',
             $job
         );
+
+        return ['buffered_job_id' => $job['buffered_job_id']];
     }
 
     public function markJobAsCompleted($job)

--- a/src/Hodor/JobQueue/BufferQueue.php
+++ b/src/Hodor/JobQueue/BufferQueue.php
@@ -47,25 +47,8 @@ class BufferQueue
     public function processBuffer()
     {
         $this->message_queue->consume(function ($message) {
-            $content = $message->getContent();
-            $name    = $content['name'];
-            $params  = $content['params'];
-            $options = $content['options'];
-            $meta    = $content['meta'];
-
-            $worker_queue = $this->queue_factory->getWorkerQueueForJob(
-                $name,
-                $params,
-                $options
-            );
-
-            $worker_queue->push(
-                $name,
-                $params,
-                $meta
-            );
-
-            $message->acknowledge();
+            $superqueue = $this->queue_factory->getSuperqueue();
+            $superqueue->bufferJobFromBufferQueueToDatabase($message);
 
             exit(0);
         });

--- a/src/Hodor/JobQueue/Config.php
+++ b/src/Hodor/JobQueue/Config.php
@@ -50,6 +50,14 @@ class Config
     }
 
     /**
+     * @return array
+     */
+    public function getSuperqueueConfig()
+    {
+        return $this->getOption('superqueue');
+    }
+
+    /**
      * @param  string $queue_name
      * @return array
      */

--- a/src/Hodor/JobQueue/Config.php
+++ b/src/Hodor/JobQueue/Config.php
@@ -39,10 +39,10 @@ class Config
      */
     public function getDatabaseConfig()
     {
-        $superqueuer_config = $this->getOption('superqueuer');
+        $superqueuer_config = $this->getOption('superqueue');
         if (!isset($superqueuer_config['database'])) {
             throw new Exception(
-                "The 'database' config was not found in the 'superqueuer' config."
+                "The 'database' config was not found in the 'superqueue' config."
             );
         }
 

--- a/src/Hodor/JobQueue/QueueFactory.php
+++ b/src/Hodor/JobQueue/QueueFactory.php
@@ -102,7 +102,8 @@ class QueueFactory
 
         $queue_config = $this->config->getWorkerQueueConfig($queue_name);
         $this->worker_queues[$queue_name] = new WorkerQueue(
-            $this->getMessageQueue($queue_config)
+            $this->getMessageQueue($queue_config),
+            $this
         );
 
         return $this->worker_queues[$queue_name];

--- a/src/Hodor/JobQueue/QueueFactory.php
+++ b/src/Hodor/JobQueue/QueueFactory.php
@@ -39,6 +39,21 @@ class QueueFactory
     }
 
     /**
+     * @return Superqueue
+     */
+    public function getSuperqueue()
+    {
+        if (isset($this->superqueue)) {
+            return $this->superqueue;
+        }
+
+        $queue_config = $this->config->getSuperqueueConfig();
+        $this->superqueue = new Superqueue($queue_config, $this);
+
+        return $this->superqueue;
+    }
+
+    /**
      * @param  string $queue_name [description]
      * @return \Hodor\JobQueue\BufferQueue
      */
@@ -99,16 +114,14 @@ class QueueFactory
      * @param  array  $options
      * @return \Hodor\JobQueue\WorkerQueue
      */
-    public function getWorkerQueueForJob($name, array $params, array $options)
+    public function getWorkerQueueNameForJob($name, array $params, array $options)
     {
-        $queue_name = call_user_func(
+        return call_user_func(
             $this->config->getWorkerQueueNameFactory(),
             $name,
             $params,
             $options
         );
-
-        return $this->getWorkerQueue($queue_name);
     }
 
     /**

--- a/src/Hodor/JobQueue/Superqueue.php
+++ b/src/Hodor/JobQueue/Superqueue.php
@@ -65,10 +65,10 @@ class Superqueue
         $db->beginTransaction();
         $job_generator = $db->getJobsToRunGenerator();
         foreach ($job_generator() as $job) {
-            $db->markJobAsQueued($job);
+            $meta = $db->markJobAsQueued($job);
 
             $queue = $this->queue_factory->getWorkerQueue($job['queue_name']);
-            $queue->push($job['queue_name'], $job['job_params']);
+            $queue->push($job['queue_name'], $job['job_params'], $meta);
         }
 
         $db->commitTransaction();

--- a/src/Hodor/JobQueue/Superqueue.php
+++ b/src/Hodor/JobQueue/Superqueue.php
@@ -81,7 +81,7 @@ class Superqueue
             $meta = $db->markJobAsQueued($job);
 
             $queue = $this->queue_factory->getWorkerQueue($job['queue_name']);
-            $queue->push($job['queue_name'], $job['job_params'], $meta);
+            $queue->push($job['job_name'], $job['job_params'], $meta);
 
             ++$jobs_queued;
         }

--- a/src/Hodor/JobQueue/Superqueue.php
+++ b/src/Hodor/JobQueue/Superqueue.php
@@ -124,8 +124,8 @@ class Superqueue
 
         $mark_finished($meta);
 
-        $message->acknowledge();
         $db->commitTransaction();
+        $message->acknowledge();
     }
 
     /**

--- a/src/Hodor/JobQueue/Superqueue.php
+++ b/src/Hodor/JobQueue/Superqueue.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Hodor\JobQueue;
+
+use Hodor\Database\AdapterFactory as DbAdapterFactory;
+use Hodor\MessageQueue\Message;
+
+class Superqueue
+{
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @var QueueFactory
+     */
+    private $queue_factory;
+
+    /**
+     * @var DbAdapterInterface
+     */
+    private $database;
+
+    /**
+     * @param QueueFactory $queue_factory
+     */
+    public function __construct(array $config, QueueFactory $queue_factory)
+    {
+        $this->config = $config;
+        $this->queue_factory = $queue_factory;
+    }
+
+    /**
+     * @param Message $message
+     */
+    public function bufferJobFromBufferQueueToDatabase(Message $message)
+    {
+        $db = $this->getDatabase();
+
+        $db->beginTransaction();
+
+        $content = $message->getContent();
+        $queue_name = $this->queue_factory->getWorkerQueueNameForJob(
+            $content['name'],
+            $content['params'],
+            $content['options']
+        );
+
+        $db->bufferJob($queue_name, [
+            'name'    => $content['name'],
+            'params'  => $content['params'],
+            'options' => $content['options'],
+            'meta'    => $content['meta'],
+        ]);
+
+        $db->commitTransaction();
+        $message->acknowledge();
+    }
+
+    /**
+     * @return DbAdapterInterface
+     */
+    private function getDatabase()
+    {
+        if ($this->database) {
+            return $this->database;
+        }
+
+        $db_adapter_factory = new DbAdapterFactory($this->config['database']);
+
+        $this->database = $db_adapter_factory->getAdapter($this->config['database']['type']);
+
+        return $this->database;
+    }
+}

--- a/src/Hodor/JobQueue/Superqueue.php
+++ b/src/Hodor/JobQueue/Superqueue.php
@@ -60,6 +60,14 @@ class Superqueue
     }
 
     /**
+     * @return bool
+     */
+    public function requestProcessLock()
+    {
+        return $this->getDatabase()->requestAdvisoryLock('superqueuer', 'default');
+    }
+
+    /**
      * @return int
      */
     public function queueJobsFromDatabaseToWorkerQueue()

--- a/src/Hodor/JobQueue/WorkerQueue.php
+++ b/src/Hodor/JobQueue/WorkerQueue.php
@@ -9,14 +9,21 @@ class WorkerQueue
     /**
      * @var Queue
      */
-    private $queue;
+    private $message_queue;
 
     /**
-     * @param Queue $queue
+     * @var QueueFactory
      */
-    public function __construct(Queue $queue)
+    private $queue_factory;
+
+    /**
+     * @param Queue $message_queue
+     * @param QueueFactory $queue_factory
+     */
+    public function __construct(Queue $message_queue, QueueFactory $queue_factory)
     {
-        $this->queue = $queue;
+        $this->message_queue = $message_queue;
+        $this->queue_factory = $queue_factory;
     }
 
     /**
@@ -26,7 +33,7 @@ class WorkerQueue
      */
     public function push($name, array $params = [], array $meta = [])
     {
-        $this->queue->push([
+        $this->message_queue->push([
             'name'   => $name,
             'params' => $params,
             'meta'   => $meta,
@@ -38,7 +45,7 @@ class WorkerQueue
      */
     public function runNext(callable $job_runner)
     {
-        $this->queue->consume(function ($message) use ($job_runner) {
+        $this->message_queue->consume(function ($message) use ($job_runner) {
             register_shutdown_function(function ($message) {
                 if (error_get_last()) {
                     $message->acknowledge();

--- a/src/Hodor/JobQueue/WorkerQueue.php
+++ b/src/Hodor/JobQueue/WorkerQueue.php
@@ -2,6 +2,7 @@
 
 namespace Hodor\JobQueue;
 
+use DateTime;
 use Hodor\MessageQueue\Queue;
 
 class WorkerQueue
@@ -46,18 +47,25 @@ class WorkerQueue
     public function runNext(callable $job_runner)
     {
         $this->message_queue->consume(function ($message) use ($job_runner) {
-            register_shutdown_function(function ($message) {
+            $start_time = new DateTime;
+
+            register_shutdown_function(function ($message, $start_time, $queue_factory) {
                 if (error_get_last()) {
-                    $message->acknowledge();
+                    $queue_factory->getSuperqueue()->markJobAsFailed(
+                        $message,
+                        $start_time
+                    );
+                    exit(1);
                 }
-            }, $message);
+            }, $message, $start_time, $this->queue_factory);
 
             $content = $message->getContent();
             $name = $content['name'];
             $params = $content['params'];
             call_user_func($job_runner, $name, $params);
 
-            $message->acknowledge();
+            $superqueue = $this->queue_factory->getSuperqueue();
+            $superqueue->markJobAsSuccessful($message, $start_time);
 
             exit(0);
         });

--- a/tests/src/Hodor/JobQueue/ConfigTest.php
+++ b/tests/src/Hodor/JobQueue/ConfigTest.php
@@ -32,8 +32,8 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             [
-                'type' => $options['superqueuer']['database']['type'],
-                'dsn'  => $options['superqueuer']['database']['dsn'],
+                'type' => $options['superqueue']['database']['type'],
+                'dsn'  => $options['superqueue']['database']['dsn'],
             ],
             [
                 'type' => $db_config['type'],
@@ -429,7 +429,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     {
         return [
             [[
-                'superqueuer' => [
+                'superqueue' => [
                     'database' => [
                         'type' => 'pgsql',
                         'dsn'  => 'host=localhost user=test_hodor dbname=test_hodor',


### PR DESCRIPTION
For issue #21

This PR addresses:
- Update the buffer worker to move jobs from the buffer queue in RabbitMQ to the database rather than directly to the worker queue
- Create a superqueuer to queue jobs from the database to the RabbitMQ worker queue

Right now this basically adds overhead without changing any functionality (besides job tracking), but this opens the door for job throttling, job ranks, etc.
