### PR TITLE
Use config.test.php rather than static config

### DIFF
--- a/tests/src/Hodor/Config/LoaderFacadeTest.php
+++ b/tests/src/Hodor/Config/LoaderFacadeTest.php
@@ -25,7 +25,7 @@ class LoaderFacadeTest extends PHPUnit_Framework_TestCase
 
     public function testFacadeReturnsConfig()
     {
-        $file_path = __DIR__ . '/PhpConfig.php';
+        $file_path = __DIR__ . '/../../../../config/config.test.php';
 
         LoaderFacade::setLoaderFactory(null);
         $this->assertInstanceOf(

--- a/tests/src/Hodor/Config/LoaderFactoryTest.php
+++ b/tests/src/Hodor/Config/LoaderFactoryTest.php
@@ -43,7 +43,7 @@ class LoaderFactoryTest extends PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf(
             '\Hodor\JobQueue\Config',
-            $this->loader_factory->loadFromFile(__DIR__ . '/PhpConfig.php')
+            $this->loader_factory->loadFromFile(__DIR__ . '/../../../../config/config.test.php')
         );
     }
 }

--- a/tests/src/Hodor/Config/PhpConfig.php
+++ b/tests/src/Hodor/Config/PhpConfig.php
@@ -1,2 +1,0 @@
-<?php
-return ['database' => []];

--- a/tests/src/Hodor/Config/PhpConfigLoaderTest.php
+++ b/tests/src/Hodor/Config/PhpConfigLoaderTest.php
@@ -35,7 +35,7 @@ class PhpConfigLoaderTest extends PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf(
             '\Hodor\JobQueue\Config',
-            $this->loader->loadFromFile(__DIR__ . '/PhpConfig.php')
+            $this->loader->loadFromFile(__DIR__ . '/../../../../config/config.test.php')
         );
     }
 }

--- a/tests/src/Hodor/JobQueue/JobQueueTest.php
+++ b/tests/src/Hodor/JobQueue/JobQueueTest.php
@@ -15,7 +15,7 @@ class JobQueueTest extends PHPUnit_Framework_TestCase
 
     public function testConfigCanBeLoadedFromFile()
     {
-        $this->job_queue->setConfigFile(__DIR__ . '/../Config/PhpConfig.php');
+        $this->job_queue->setConfigFile(__DIR__ . '/../../../../config/config.test.php');
         $this->assertTrue(
             $this->job_queue->getConfig() instanceof \Hodor\JobQueue\Config
         );


### PR DESCRIPTION
The static config existed before config.test.php was added as a required
testing configuration requirement.
