### PR TITLE
Remove higher order implementation of generators

### DIFF
--- a/src/Hodor/Database/Driver/YoPdoDriver.php
+++ b/src/Hodor/Database/Driver/YoPdoDriver.php
@@ -36,17 +36,15 @@ class YoPdoDriver
 
     /**
      * @param  string $sql
-     * @return callable generator
+     * @return generator
      */
     public function selectRowGenerator($sql)
     {
         $result = $this->getYoPdo()->query($sql);
 
-        return function () use ($result) {
-            while ($row = $result->fetch()) {
-                yield $row;
-            }
-        };
+        while ($row = $result->fetch()) {
+            yield $row;
+        }
     }
 
     /**

--- a/src/Hodor/Database/PgsqlAdapter.php
+++ b/src/Hodor/Database/PgsqlAdapter.php
@@ -48,7 +48,7 @@ class PgsqlAdapter implements AdapterInterface
     }
 
     /**
-     * @return callable
+     * @return generator
      */
     public function getJobsToRunGenerator()
     {
@@ -63,7 +63,7 @@ ORDER BY
 SQL;
 
             $row_generator = $this->getDriver()->selectRowGenerator($sql);
-            foreach ($row_generator() as $job) {
+            foreach ($row_generator as $job) {
                 $job['job_params'] = json_decode($job['job_params'], true);
                 yield $job;
             }

--- a/src/Hodor/Database/Phpmig/PgsqlPhpmigAdapter.php
+++ b/src/Hodor/Database/Phpmig/PgsqlPhpmigAdapter.php
@@ -34,7 +34,7 @@ SQL;
 
         $versions = [];
         $row_generator = $this->driver->selectRowGenerator($sql);
-        foreach ($row_generator() as $row) {
+        foreach ($row_generator as $row) {
             $versions[] = $row['version'];
         }
 

--- a/tests/src/Hodor/Database/DriverTest.php
+++ b/tests/src/Hodor/Database/DriverTest.php
@@ -46,7 +46,8 @@ SELECT 3 AS col
 SQL;
         $row_generator = $adapter->selectRowGenerator($sql);
         $count = 1;
-        foreach ($row_generator() as $row) {
+
+        foreach ($row_generator as $row) {
             $this->assertEquals($row['col'], $count);
             ++$count;
         }
@@ -59,9 +60,13 @@ SQL;
     public function testSelectRowGeneratorThrowsAnExceptionOnError($adapter)
     {
         $sql = <<<SQL
-SELECT 1 FROM not_there;
+SELECT 1 FROM not_here;
 SQL;
-        $adapter->selectRowGenerator($sql);
+
+        foreach ($adapter->selectRowGenerator($sql) as $row) {
+            // an exception will be thrown as soon as
+            // we try to retrieve the results
+        }
     }
 
     /**


### PR DESCRIPTION
Ignorance made me believe that returning the generator
in a higher order function was required so the same
generator would not be used over and over, potentially
creating conflicts. In fact, it will not create a conflict
so using higher order functions to "fix" an issue that
is not there is in fact just complicating matters.

The higher order function has been removed to make things
more clear
