### PR TITLE
Require \DateTime for run_after job option

### DIFF
--- a/bin/test-publisher.php
+++ b/bin/test-publisher.php
@@ -12,9 +12,15 @@ $queue_name = $args->getQueueName();
 $job_name = $args->getJobName();
 $job_params = $args->getJobParams();
 
+$job_options = ['queue_name' => $queue_name];
+
+if (!empty($job_params['job_options']['run_after'])) {
+    $job_options['run_after'] = new \DateTime($job_params['job_options']['run_after']);
+}
+
 Q::setConfigFile($config_file);
 Q::push(
     $job_name,
     $job_params,
-    ['queue_name' => $queue_name]
+    $job_options
 );

--- a/src/Hodor/JobQueue/BufferQueue.php
+++ b/src/Hodor/JobQueue/BufferQueue.php
@@ -35,6 +35,10 @@ class BufferQueue
     {
         $this->queue_factory->getJobOptionsValidator()->validateJobOptions($options);
 
+        if (!empty($options['run_after'])) {
+            $options['run_after'] = $options['run_after']->format('c');
+        }
+
         $this->message_queue->push([
             'name'    => $name,
             'params'  => $params,

--- a/src/Hodor/JobQueue/JobOptions/Validator.php
+++ b/src/Hodor/JobQueue/JobOptions/Validator.php
@@ -79,10 +79,10 @@ class Validator
      */
     private function validateRunAfter(array $options)
     {
-        if (false !== strtotime($options['run_after'])) {
+        if ($options['run_after'] instanceof DateTime) {
             return;
         }
 
-        throw new Exception('\'run_after\' must be a date/time string');
+        throw new Exception('\'run_after\' must be an instance of \DateTime');
     }
 }

--- a/tests/src/Hodor/FlowTest.php
+++ b/tests/src/Hodor/FlowTest.php
@@ -44,7 +44,13 @@ class FlowTest extends PHPUnit_Framework_TestCase
         $bin_path = __DIR__ . '/../../../bin';
 
         $job_name = 'job-name-' . uniqid();
-        $job_params = ['the_time' => date('c'), 'known_value' => 'donuts'];
+        $job_params = [
+            'the_time'    => date('c'),
+            'known_value' => 'donuts',
+            'job_options' => [
+                'run_after' => date('c'),
+            ],
+        ];
         $e_job_name = escapeshellarg($job_name);
         $e_job_params = escapeshellarg(json_encode($job_params));
 

--- a/tests/src/Hodor/JobQueue/JobOptions/ValidatorTest.php
+++ b/tests/src/Hodor/JobQueue/JobOptions/ValidatorTest.php
@@ -33,14 +33,14 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
     /**
      * @expectedException \Exception
      */
-    public function testRunAfterThrowsAnExceptionIfItIsNotAValidDateTimeString()
+    public function testRunAfterThrowsAnExceptionIfItIsNotADateTimeObject()
     {
-        $this->generateValidator()->validateJobOptions(['run_after' => 'haha']);
+        $this->generateValidator()->validateJobOptions(['run_after' => '2015-12-12']);
     }
 
     public function testRunAfterCanValidateWithoutAnException()
     {
-        $this->generateValidator()->validateJobOptions(['run_after' => date('c')]);
+        $this->generateValidator()->validateJobOptions(['run_after' => new DateTime()]);
     }
 
     /**


### PR DESCRIPTION
Requiring a \DateTime rather than allowing any
string will reduce needing to manage the flexibility
known as edge cases. If someone runs into issues with
date formatting, it will most likely be the way they
are using PHP :)

Issue #67
