### PR TITLE
Add mutex_id job option

### DIFF
--- a/bin/test-publisher.php
+++ b/bin/test-publisher.php
@@ -20,6 +20,9 @@ if (!empty($job_params['job_options']['run_after'])) {
 if (!empty($job_params['job_options']['job_rank'])) {
     $job_options['job_rank'] = $job_params['job_options']['job_rank'];
 }
+if (!empty($job_params['job_options']['mutex_id'])) {
+    $job_options['mutex_id'] = $job_params['job_options']['mutex_id'];
+}
 
 Q::setConfigFile($config_file);
 Q::push(

--- a/migrations/postgres/20151228082041_AddMutexId.php
+++ b/migrations/postgres/20151228082041_AddMutexId.php
@@ -1,0 +1,68 @@
+<?php
+
+use Hodor\Database\AdapterInterface as DbAdapterInterface;
+use Hodor\Database\Phpmig\Migration;
+
+class AddMutexId extends Migration
+{
+    /**
+     * @param DbAdapterInterface $db
+     * @return void
+     */
+    protected function transactionalUp(DbAdapterInterface $db)
+    {
+        $sql = <<<SQL
+ALTER TABLE buffered_jobs
+    ADD COLUMN mutex_id VARCHAR DEFAULT 'hodor:' || currval('buffered_jobs_buffered_job_id_seq'::regclass);
+ALTER TABLE queued_jobs
+    ADD COLUMN mutex_id VARCHAR;
+ALTER TABLE successful_jobs
+    ADD COLUMN mutex_id VARCHAR;
+ALTER TABLE failed_jobs
+    ADD COLUMN mutex_id VARCHAR;
+
+UPDATE buffered_jobs
+SET mutex_id = 'hodor:' || buffered_job_id;
+
+UPDATE queued_jobs
+SET mutex_id = 'hodor:' || buffered_job_id;
+
+UPDATE successful_jobs
+SET mutex_id = 'hodor:' || buffered_job_id;
+
+UPDATE failed_jobs
+SET mutex_id = 'hodor:' || buffered_job_id;
+
+ALTER TABLE buffered_jobs
+    ALTER COLUMN mutex_id SET NOT NULL;
+ALTER TABLE queued_jobs
+    ALTER COLUMN mutex_id SET NOT NULL;
+ALTER TABLE successful_jobs
+    ALTER COLUMN mutex_id SET NOT NULL;
+ALTER TABLE failed_jobs
+    ALTER COLUMN mutex_id SET NOT NULL;
+SQL;
+
+        $db->queryMultiple($sql);
+    }
+
+    /**
+     * @param DbAdapterInterface $db
+     * @return void
+     */
+    protected function transactionalDown(DbAdapterInterface $db)
+    {
+        $sql = <<<SQL
+ALTER TABLE buffered_jobs
+    DROP COLUMN mutex_id;
+ALTER TABLE queued_jobs
+    DROP COLUMN mutex_id;
+ALTER TABLE successful_jobs
+    DROP COLUMN mutex_id;
+ALTER TABLE failed_jobs
+    DROP COLUMN mutex_id;
+SQL;
+
+        $db->queryMultiple($sql);
+    }
+}

--- a/src/Hodor/JobQueue/JobOptions/Validator.php
+++ b/src/Hodor/JobQueue/JobOptions/Validator.php
@@ -20,6 +20,7 @@ class Validator
         'queue_name' => 'validateQueueName',
         'run_after' => 'validateRunAfter',
         'job_rank' => 'validateJobRank',
+        'mutex_id' => 'validateMutexId',
     ];
 
     /**
@@ -100,5 +101,18 @@ class Validator
         }
 
         throw new Exception('\'job_rank\' must be an integer between -20 and 19');
+    }
+
+    /**
+     * @param array $options
+     * @throws Exception
+     */
+    private function validateMutexId(array $options)
+    {
+        if (is_scalar($options['mutex_id']) && strlen("{$options['mutex_id']}") >= 1) {
+            return;
+        }
+
+        throw new Exception('Custom \'mutex_id\' values must be strings of at least 1 character in length');
     }
 }

--- a/tests/src/Hodor/FlowTest.php
+++ b/tests/src/Hodor/FlowTest.php
@@ -74,6 +74,49 @@ class FlowTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testMutexJobsAreProperlyMutexed()
+    {
+        $bin_path = __DIR__ . '/../../../bin';
+
+        $job_name = 'job-name-' . uniqid();
+        $jobs = [
+            1 => ['job_number' => 1, 'job_options' => ['mutex_id' => 'mutex-a', 'job_rank' => 5]],
+            2 => ['job_number' => 2, 'job_options' => ['mutex_id' => 'mutex-a', 'job_rank' => 5]],
+            3 => ['job_number' => 3, 'job_options' => ['mutex_id' => 'mutex-b', 'job_rank' => 6]],
+        ];
+        $e_job_name = escapeshellarg($job_name);
+
+        foreach ($jobs as $job) {
+            $e_job_params = escapeshellarg(json_encode($job));
+            $this->runCommand(
+                "php {$bin_path}/test-publisher.php"
+                . " -c {$this->e_config_file}"
+                . " -q the-worker-q-name"
+                . " --job-name {$e_job_name}"
+                . " --job-params {$e_job_params}"
+            );
+        }
+        for ($i = 0; $i < 3; $i++) {
+            $this->runCommand("php {$bin_path}/buffer-worker.php -c {$this->e_config_file} -q default");
+        }
+
+        $this->runCommand("php {$bin_path}/superqueuer.php -c {$this->e_config_file}");
+
+        foreach ([1, 3] as $job_idx) {
+            $this->assertEquals(
+                json_encode(
+                    [
+                        'name' => $job_name,
+                        'params' => $jobs[$job_idx],
+                    ]
+                ),
+                $this->runCommand(
+                    "php {$bin_path}/job-worker.php -c {$this->e_config_file} -q the-worker-q-name"
+                )
+            );
+        }
+    }
+
     /**
      * @param string $command
      * @throws Exception


### PR DESCRIPTION
The mutex_id job option allows for jobs to be limited
in a way that only one job per any given mutex_id can
be ran at the same time.  If multiple jobs have the
same mutex_id, only one of them will be superqueued at
a time—the others with the same mutex_id will wait for
the corresponding queued job to completed before being
superqueued
