### PR TITLE
Fix exception throwing in SupervisordManager#setupDaemon()

### DIFF
--- a/src/Hodor/Daemon/SupervisordManager.php
+++ b/src/Hodor/Daemon/SupervisordManager.php
@@ -33,7 +33,10 @@ class SupervisordManager implements ManagerInterface
             $config_contents .= $this->generateProgramText($program) . "\n";
         }
 
-        if (!file_put_contents($config_path, $config_contents)) {
+        if (!is_writable(dirname($config_path))
+            || (file_exists($config_path) && !is_writable($config_path))
+            || false === file_put_contents($config_path, $config_contents)
+        ) {
             throw new Exception("Could not write to config file '{$config_path}'.\n");
         }
     }

--- a/tests/src/Hodor/Daemon/SupervisordManagerTest.php
+++ b/tests/src/Hodor/Daemon/SupervisordManagerTest.php
@@ -74,6 +74,19 @@ class SupervisordManagerTest extends PHPUnit_Framework_TestCase
         return $rows;
     }
 
+    /**
+     * @expectedException \Exception
+     */
+    public function testSetupDaemonThrowsAnExceptionIfConfigFileIsNotWritable()
+    {
+        $hodor_base_path = dirname(dirname(dirname(dirname(__DIR__))));
+
+        $supervisord_config_path = __DIR__ . '/../../../../tests/non-existent/supervisord.' . uniqid() . '.conf';
+        $manager = $this->getSupervisordManager($supervisord_config_path);
+
+        $manager->setupDaemon();
+    }
+
     public function testSetupDaemonGeneratesSupervisordConfig()
     {
         $hodor_base_path = dirname(dirname(dirname(dirname(__DIR__))));


### PR DESCRIPTION
file_put_contents() will throw a PHP warning if the file is
not writable, so the exception will not be thrown in cases
where the error handler exits on error. Checking to see if
the file is writable before writing the file will prevent
these warnings.
