### PR TITLE
Throw an exception if json_encode() of job fails

### DIFF
--- a/src/Hodor/MessageQueue/Queue.php
+++ b/src/Hodor/MessageQueue/Queue.php
@@ -2,6 +2,7 @@
 
 namespace Hodor\MessageQueue;
 
+use Exception;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Message\AMQPMessage;
 
@@ -31,8 +32,13 @@ class Queue
      */
     public function push($message)
     {
+        $json_message = json_encode($message, JSON_FORCE_OBJECT);
+        if (false === $json_message) {
+            throw new Exception("Failed to json_encode message with name '{$message['name']}'.");
+        }
+
         $amqp_message = new AMQPMessage(
-            json_encode($message, JSON_FORCE_OBJECT),
+            $json_message,
             [
                 'content_type' => 'application/json',
                 'delivery_mode' => 2


### PR DESCRIPTION
Throw an exception in Queue#push() if json_encode fails so we do not end up with invalid jobs being queued.

If the data being json_encoded in Queue#push() contains an object or a deeply-nested array (512+ levels), json_encode will return false. This false is then passed to RabbitMQ as the message content, which creates problems when reading the message in the buffer worker.

Issue #78
