### PR TITLE
Acknowledge RabbitMQ message even if job not found in DB

### DIFF
--- a/src/Hodor/Database/Exception/BufferedJobNotFoundException.php
+++ b/src/Hodor/Database/Exception/BufferedJobNotFoundException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Hodor\Database\Exception;
+
+use Exception;
+
+class BufferedJobNotFoundException extends Exception
+{
+    /**
+     * @param string $message
+     * @param int $buffered_job_id
+     * @param array $meta
+     */
+    public function __construct($message, $buffered_job_id, array $meta)
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Hodor/Database/PgsqlAdapter.php
+++ b/src/Hodor/Database/PgsqlAdapter.php
@@ -3,6 +3,7 @@
 namespace Hodor\Database;
 
 use Hodor\Database\Driver\YoPdoDriver;
+use Hodor\Database\Exception\BufferedJobNotFoundException;
 use Hodor\Database\Phpmig\PgsqlPhpmigAdapter;
 
 class PgsqlAdapter implements AdapterInterface
@@ -208,6 +209,14 @@ SQL;
             $sql,
             ['buffered_job_id' => $meta['buffered_job_id']]
         );
+        if (!$job) {
+            throw new BufferedJobNotFoundException(
+                "Could not mark buffered_job_id={$meta['buffered_job_id']} as finished. Job not found.",
+                $meta['buffered_job_id'],
+                $meta
+            );
+        }
+
         $job['started_running_at'] = $meta['started_running_at'];
         $job['ran_from'] = gethostname();
         $job['dequeued_from'] = gethostname();


### PR DESCRIPTION
In some cases a job will be acknowledged in the DB but not
in RabbitMQ, which will cause the job to re-run when the
worker picks the message back up out of RabbitMQ.  When the
job is re-ran, the database queries to acknowledge the job
in the DB would fail because the job would no longer be in
buffered_jobs.  As a result the job again would not be ack'ed
in RabbitMQ.  This would cause the job to re-run over and over.

It would be best to acknowledge the message in RabbitMQ and
re-throw the exception so we know about the issue but also
allow for the issue to self-heal.

Issue #82
