### PR TITLE
Limit job_params nesting to prevent encoding issues

### DIFF
--- a/src/Hodor/MessageQueue/Queue.php
+++ b/src/Hodor/MessageQueue/Queue.php
@@ -32,7 +32,7 @@ class Queue
      */
     public function push($message)
     {
-        $json_message = json_encode($message, JSON_FORCE_OBJECT);
+        $json_message = json_encode($message, JSON_FORCE_OBJECT, 100);
         if (false === $json_message) {
             throw new Exception("Failed to json_encode message with name '{$message['name']}'.");
         }


### PR DESCRIPTION
json_encode() can theoretically have issues later in
the job queue flow if the buffer queue allows for the
default maximum level of nesting that json_encode allows
for to be used up

Issue #86 
