### PR TITLE
Rename transactions to batches

### DIFF
--- a/src/Hodor/JobQueue/JobQueue.php
+++ b/src/Hodor/JobQueue/JobQueue.php
@@ -42,19 +42,19 @@ class JobQueue
         );
     }
 
-    public function beginTransaction()
+    public function beginBatch()
     {
-        $this->getQueueFactory()->beginTransaction();
+        $this->getQueueFactory()->beginBatch();
     }
 
-    public function commitTransaction()
+    public function publishBatch()
     {
-        $this->getQueueFactory()->commitTransaction();
+        $this->getQueueFactory()->publishBatch();
     }
 
-    public function rollbackTransaction()
+    public function discardBatch()
     {
-        $this->getQueueFactory()->rollbackTransaction();
+        $this->getQueueFactory()->discardBatch();
     }
 
     /**

--- a/src/Hodor/JobQueue/QueueFactory.php
+++ b/src/Hodor/JobQueue/QueueFactory.php
@@ -142,19 +142,19 @@ class QueueFactory
         return $this->job_options_validator;
     }
 
-    public function beginTransaction()
+    public function beginBatch()
     {
-        $this->getMessageQueueFactory()->beginTransaction();
+        $this->getMessageQueueFactory()->beginBatch();
     }
 
-    public function commitTransaction()
+    public function publishBatch()
     {
-        $this->getMessageQueueFactory()->commitTransaction();
+        $this->getMessageQueueFactory()->publishBatch();
     }
 
-    public function rollbackTransaction()
+    public function discardBatch()
     {
-        $this->getMessageQueueFactory()->rollbackTransaction();
+        $this->getMessageQueueFactory()->discardBatch();
     }
 
     /**

--- a/src/Hodor/JobQueue/Superqueue.php
+++ b/src/Hodor/JobQueue/Superqueue.php
@@ -76,7 +76,7 @@ class Superqueue
     {
         $db = $this->getDatabase();
 
-        $this->queue_factory->beginTransaction();
+        $this->queue_factory->beginBatch();
         $db->beginTransaction();
 
         $job_generator = $db->getJobsToRunGenerator();
@@ -94,7 +94,7 @@ class Superqueue
         // message is pushed to Rabbit MQ to prevent jobs from being
         // processed by workers before they have been moved to buffered_jobs
         $db->commitTransaction();
-        $this->queue_factory->commitTransaction();
+        $this->queue_factory->publishBatch();
 
         return $jobs_queued;
     }

--- a/src/Hodor/MessageQueue/QueueFactory.php
+++ b/src/Hodor/MessageQueue/QueueFactory.php
@@ -24,7 +24,7 @@ class QueueFactory
     /**
      * @var bool
      */
-    private $is_in_transaction = false;
+    private $is_in_batch = false;
 
     /**
      * @param array $queue_config
@@ -42,35 +42,35 @@ class QueueFactory
             $queue_config,
             $this->getAmqpChannel($queue_config)
         );
-        if ($this->is_in_transaction) {
-            $this->queues[$queue_name]->beginTransaction();
+        if ($this->is_in_batch) {
+            $this->queues[$queue_name]->beginBatch();
         }
 
         return $this->queues[$queue_name];
     }
 
-    public function beginTransaction()
+    public function beginBatch()
     {
         array_walk($this->queues, function (Queue $queue) {
-            $queue->beginTransaction();
+            $queue->beginBatch();
         });
-        $this->is_in_transaction = true;
+        $this->is_in_batch = true;
     }
 
-    public function commitTransaction()
+    public function publishBatch()
     {
         array_walk($this->queues, function (Queue $queue) {
-            $queue->commitTransaction();
+            $queue->publishBatch();
         });
-        $this->is_in_transaction = false;
+        $this->is_in_batch = false;
     }
 
-    public function rollbackTransaction()
+    public function discardBatch()
     {
         array_walk($this->queues, function (Queue $queue) {
-            $queue->rollbackTransaction();
+            $queue->discardBatch();
         });
-        $this->is_in_transaction = false;
+        $this->is_in_batch = false;
     }
 
     /**


### PR DESCRIPTION
The functionality is better described as batches because
it does not affect reading messages from Rabbit.
