### PR TITLE
Rename JobQueue\QueueFactory to QueueManager

### DIFF
--- a/bin/buffer-worker.php
+++ b/bin/buffer-worker.php
@@ -5,14 +5,14 @@ require_once __DIR__ . '/../bootstrap.php';
 
 use Hodor\Command\Arguments as Arguments;
 use Hodor\Config\LoaderFacade as Config;
-use Hodor\JobQueue\QueueFactory as QueueFactory;
+use Hodor\JobQueue\QueueManager;
 
 $args = new Arguments();
 $config_file = $args->getConfigFile();
 $queue_name = $args->getQueueName();
 
 $config = Config::loadFromFile($config_file);
-$queue_factory = new QueueFactory($config);
-$buffer_worker = $queue_factory->getBufferQueue($queue_name);
+$queue_manager = new QueueManager($config);
+$buffer_worker = $queue_manager->getBufferQueue($queue_name);
 
 $buffer_worker->processBuffer();

--- a/bin/job-worker.php
+++ b/bin/job-worker.php
@@ -5,14 +5,14 @@ require_once __DIR__ . '/../bootstrap.php';
 
 use Hodor\Command\Arguments as Arguments;
 use Hodor\Config\LoaderFacade as Config;
-use Hodor\JobQueue\QueueFactory as QueueFactory;
+use Hodor\JobQueue\QueueManager;
 
 $args = new Arguments();
 $config_file = $args->getConfigFile();
 $queue_name = $args->getQueueName();
 
 $config = Config::loadFromFile($config_file);
-$queue_factory = new QueueFactory($config);
-$worker_queue = $queue_factory->getWorkerQueue($queue_name);
+$queue_maanger = new QueueManager($config);
+$worker_queue = $queue_maanger->getWorkerQueue($queue_name);
 
 $worker_queue->runNext($config->getJobRunnerFactory());

--- a/bin/superqueuer.php
+++ b/bin/superqueuer.php
@@ -5,14 +5,14 @@ require_once __DIR__ . '/../bootstrap.php';
 
 use Hodor\Command\Arguments as Arguments;
 use Hodor\Config\LoaderFacade as Config;
-use Hodor\JobQueue\QueueFactory as QueueFactory;
+use Hodor\JobQueue\QueueManager;
 
 $args = new Arguments();
 $config_file = $args->getConfigFile();
 
 $config = Config::loadFromFile($config_file);
-$queue_factory = new QueueFactory($config);
-$superqueue = $queue_factory->getSuperqueue();
+$queue_manager = new QueueManager($config);
+$superqueue = $queue_manager->getSuperqueue();
 
 if (!$superqueue->requestProcessLock()) {
     sleep(5);

--- a/src/Hodor/JobQueue/BufferQueue.php
+++ b/src/Hodor/JobQueue/BufferQueue.php
@@ -12,18 +12,18 @@ class BufferQueue
     private $message_queue;
 
     /**
-     * @var QueueFactory
+     * @var QueueManager
      */
-    private $queue_factory;
+    private $queue_manager;
 
     /**
      * @param Queue $message_queue
-     * @param QueueFactory $queue_factory
+     * @param QueueManager $queue_manager
      */
-    public function __construct(Queue $message_queue, QueueFactory $queue_factory)
+    public function __construct(Queue $message_queue, QueueManager $queue_manager)
     {
         $this->message_queue = $message_queue;
-        $this->queue_factory = $queue_factory;
+        $this->queue_manager = $queue_manager;
     }
 
     /**
@@ -33,7 +33,7 @@ class BufferQueue
      */
     public function push($name, array $params = [], array $options = [])
     {
-        $this->queue_factory->getJobOptionsValidator()->validateJobOptions($options);
+        $this->queue_manager->getJobOptionsValidator()->validateJobOptions($options);
 
         if (!empty($options['run_after'])) {
             $options['run_after'] = $options['run_after']->format('c');
@@ -53,7 +53,7 @@ class BufferQueue
     public function processBuffer()
     {
         $this->message_queue->consume(function ($message) {
-            $superqueue = $this->queue_factory->getSuperqueue();
+            $superqueue = $this->queue_manager->getSuperqueue();
             $superqueue->bufferJobFromBufferQueueToDatabase($message);
 
             exit(0);

--- a/src/Hodor/JobQueue/JobQueue.php
+++ b/src/Hodor/JobQueue/JobQueue.php
@@ -18,9 +18,9 @@ class JobQueue
     private $config;
 
     /**
-     * @var QueueFactory
+     * @var QueueManager
      */
-    private $queue_factory;
+    private $queue_manager;
 
     /**
      * @param string $job_name the name of the job to run
@@ -29,7 +29,7 @@ class JobQueue
      */
     public function push($job_name, array $params = [], array $options = [])
     {
-        $buffer_queue = $this->getQueueFactory()->getBufferQueueForJob(
+        $buffer_queue = $this->getQueueManager()->getBufferQueueForJob(
             $job_name,
             $params,
             $options
@@ -44,17 +44,17 @@ class JobQueue
 
     public function beginBatch()
     {
-        $this->getQueueFactory()->beginBatch();
+        $this->getQueueManager()->beginBatch();
     }
 
     public function publishBatch()
     {
-        $this->getQueueFactory()->publishBatch();
+        $this->getQueueManager()->publishBatch();
     }
 
     public function discardBatch()
     {
-        $this->getQueueFactory()->discardBatch();
+        $this->getQueueManager()->discardBatch();
     }
 
     /**
@@ -88,24 +88,24 @@ class JobQueue
     }
 
     /**
-     * @param QueueFactory $queue_factory
+     * @param QueueManager $queue_manager
      */
-    public function setQueueFactory(QueueFactory $queue_factory)
+    public function setQueueManager(QueueManager $queue_manager)
     {
-        $this->queue_factory = $queue_factory;
+        $this->queue_manager = $queue_manager;
     }
 
     /**
-     * @return QueueFactory
+     * @return QueueManager
      */
-    private function getQueueFactory()
+    private function getQueueManager()
     {
-        if ($this->queue_factory) {
-            return $this->queue_factory;
+        if ($this->queue_manager) {
+            return $this->queue_manager;
         }
 
-        $this->queue_factory = new QueueFactory($this->getConfig());
+        $this->queue_manager = new QueueManager($this->getConfig());
 
-        return $this->queue_factory;
+        return $this->queue_manager;
     }
 }

--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -6,7 +6,7 @@ use Hodor\JobQueue\JobOptions\Validator as JobOptionsValidator;
 use Hodor\MessageQueue\Queue as MessageQueue;
 use Hodor\MessageQueue\QueueFactory as MqFactory;
 
-class QueueFactory
+class QueueManager
 {
     /**
      * @param Config
@@ -24,7 +24,7 @@ class QueueFactory
     private $worker_queues = [];
 
     /**
-     * @var QueueFactory
+     * @var QueueManager
      */
     private $mq_factory;
 
@@ -167,7 +167,7 @@ class QueueFactory
     }
 
     /**
-     * @return QueueFactory
+     * @return QueueManager
      */
     private function getMessageQueueFactory()
     {

--- a/tests/src/Hodor/JobQueue/JobQueueTest.php
+++ b/tests/src/Hodor/JobQueue/JobQueueTest.php
@@ -57,11 +57,11 @@ class JobQueueTest extends PHPUnit_Framework_TestCase
                 $job_options
             );
 
-        $queue_factory = $this->getMockBuilder('\Hodor\JobQueue\QueueFactory')
+        $queue_manager = $this->getMockBuilder('\Hodor\JobQueue\QueueManager')
             ->disableOriginalConstructor()
             ->setMethods(['getBufferQueueForJob'])
             ->getMock();
-        $queue_factory->expects($this->once())
+        $queue_manager->expects($this->once())
             ->method('getBufferQueueForJob')
             ->with(
                 $job_name,
@@ -70,7 +70,7 @@ class JobQueueTest extends PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue($buffer_queue));
 
-        $this->job_queue->setQueueFactory($queue_factory);
+        $this->job_queue->setQueueManager($queue_manager);
         $this->job_queue->push(
             $job_name,
             $job_params,


### PR DESCRIPTION
The QueueFactory is doing way more than just generating
the queue objects. We need to make a reusable QueueFactory,
but first we need to rename QueueFactory to something that
better describes what its functionality is.
