### PR TITLE
Move json_encode from producer adapter to Queue

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Amqp/Message.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Message.php
@@ -28,29 +28,9 @@ class Message implements MessageInterface
         return $this->amqp_message->body;
     }
 
-    /**
-     * @return string
-     */
-    public function getContentType()
-    {
-        if (!$this->amqp_message->has('content_type')) {
-            return null;
-        }
-
-        return $this->amqp_message->get('content_type');
-    }
-
     public function acknowledge()
     {
         $this->amqp_message->delivery_info['channel']
             ->basic_ack($this->amqp_message->delivery_info['delivery_tag']);
-    }
-
-    /**
-     * @return AMQPMessage
-     */
-    public function getAmqpMessage()
-    {
-        return $this->amqp_message;
     }
 }

--- a/src/Hodor/MessageQueue/Adapter/Amqp/Producer.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Producer.php
@@ -31,29 +31,25 @@ class Producer implements ProducerInterface
     }
 
     /**
-     * @param MessageInterface $message
+     * @param string $message
      */
-    public function produceMessage(MessageInterface $message)
+    public function produceMessage($message)
     {
         $this->channel->basic_publish(
-            $message->getAmqpMessage(),
+            $this->generateAmqpMessage($message),
             '',
             $this->queue_name
         );
     }
 
     /**
-     * @param MessageInterface[] $messages
+     * @param string[] $messages
      */
     public function produceMessageBatch(array $messages)
     {
-        if (count($messages) == 0) {
-            return;
-        }
-
         foreach ($messages as $message) {
             $this->channel->batch_basic_publish(
-                $message->getAmqpMessage(),
+                $this->generateAmqpMessage($message),
                 '',
                 $this->queue_name
             );
@@ -62,25 +58,18 @@ class Producer implements ProducerInterface
     }
 
     /**
-     * @param mixed $message
-     * @return MessageInterface
+     * @param string $json_message
+     * @return AMQPMessage
      * @throws RuntimeException
      */
-    public function generateMessage($message)
+    private function generateAmqpMessage($json_message)
     {
-        $json_message = json_encode($message, JSON_FORCE_OBJECT, 100);
-        if (false === $json_message) {
-            throw new RuntimeException("Failed to json_encode message with name '{$message['name']}'.");
-        }
-
-        $amqp_message = new AMQPMessage(
+        return new AMQPMessage(
             $json_message,
             [
                 'content_type' => 'application/json',
                 'delivery_mode' => 2
             ]
         );
-
-        return new Message($amqp_message);
     }
 }

--- a/src/Hodor/MessageQueue/Adapter/MessageInterface.php
+++ b/src/Hodor/MessageQueue/Adapter/MessageInterface.php
@@ -9,10 +9,5 @@ interface MessageInterface
      */
     public function getContent();
 
-    /**
-     * @return string
-     */
-    public function getContentType();
-
     public function acknowledge();
 }

--- a/src/Hodor/MessageQueue/Adapter/ProducerInterface.php
+++ b/src/Hodor/MessageQueue/Adapter/ProducerInterface.php
@@ -5,18 +5,12 @@ namespace Hodor\MessageQueue\Adapter;
 interface ProducerInterface
 {
     /**
-     * @param MessageInterface $message
+     * @param string $message
      */
-    public function produceMessage(MessageInterface $message);
+    public function produceMessage($message);
 
     /**
-     * @param MessageInterface[] $messages
+     * @param string[] $messages
      */
     public function produceMessageBatch(array $messages);
-
-    /**
-     * @param mixed $message
-     * @return MessageInterface
-     */
-    public function generateMessage($message);
 }

--- a/src/Hodor/MessageQueue/Message.php
+++ b/src/Hodor/MessageQueue/Message.php
@@ -43,12 +43,7 @@ class Message
             return $this->content;
         }
 
-        $this->content = $this->message->getContent();
-
-        if ('application/json' === $this->message->getContentType()) {
-            $this->content = json_decode($this->content, true);
-        }
-
+        $this->content = json_decode($this->message->getContent(), true);
         $this->is_loaded = true;
 
         return $this->content;

--- a/src/Hodor/MessageQueue/Queue.php
+++ b/src/Hodor/MessageQueue/Queue.php
@@ -47,11 +47,11 @@ class Queue
     public function push($message)
     {
         if ($this->is_in_batch) {
-            $this->messages[] = $this->producer->generateMessage($message);
+            $this->messages[] = $this->generateMessage($message);
             return;
         }
 
-        $this->producer->produceMessage($this->producer->generateMessage($message));
+        $this->producer->produceMessage($this->generateMessage($message));
     }
 
     /**
@@ -91,5 +91,20 @@ class Queue
 
         $this->is_in_batch = false;
         $this->messages = [];
+    }
+
+    /**
+     * @param mixed $message
+     * @return string
+     * @throws RuntimeException
+     */
+    private function generateMessage($message)
+    {
+        $json_message = json_encode($message, JSON_FORCE_OBJECT, 100);
+        if (false === $json_message) {
+            throw new RuntimeException("Failed to json_encode message with name '{$message['name']}'.");
+        }
+
+        return $json_message;
     }
 }


### PR DESCRIPTION
For testing purposes, we want the `json_encode()`
(and any relevant Exception) to occur regardless of
whether the Amqp adapter or a testing adapter is used.
