### PR TITLE
Use ConfigInterface to allow MQs to be retrieved by name

### DIFF
--- a/src/Hodor/JobQueue/Config.php
+++ b/src/Hodor/JobQueue/Config.php
@@ -3,8 +3,9 @@
 namespace Hodor\JobQueue;
 
 use Exception;
+use Hodor\MessageQueue\Adapter\ConfigInterface;
 
-class Config
+class Config implements ConfigInterface
 {
     /**
      * @var string
@@ -80,7 +81,7 @@ class Config
      */
     public function getWorkerQueueConfig($queue_name)
     {
-        return $this->getQueueConfig($queue_name, 'worker');
+        return $this->getQueueConfig("worker-{$queue_name}");
     }
 
     /**
@@ -89,7 +90,7 @@ class Config
      */
     public function getBufferQueueConfig($queue_name)
     {
-        return $this->getQueueConfig($queue_name, 'bufferer');
+        return $this->getQueueConfig("bufferer-{$queue_name}");
     }
 
     /**
@@ -184,13 +185,13 @@ class Config
     }
 
     /**
-     * @param  string $queue_name
-     * @param  string $queue_type
+     * @param  string $fully_qualified_queue_name
      * @return array
      * @throws Exception
      */
-    private function getQueueConfig($queue_name, $queue_type)
+    public function getQueueConfig($fully_qualified_queue_name)
     {
+        list($queue_type, $queue_name) = explode('-', $fully_qualified_queue_name, 2);
         $queue_type_keys = $this->queue_types[$queue_type];
 
         $queues_option = $queue_type_keys['queue_key'];

--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -66,9 +66,8 @@ class QueueManager
             return $this->buffer_queues[$queue_name];
         }
 
-        $queue_config = $this->config->getBufferQueueConfig($queue_name);
         $this->buffer_queues[$queue_name] = new BufferQueue(
-            $this->getMessageQueue($queue_config),
+            $this->getMessageQueue("bufferer-{$queue_name}"),
             $this
         );
 
@@ -103,9 +102,8 @@ class QueueManager
             return $this->worker_queues[$queue_name];
         }
 
-        $queue_config = $this->config->getWorkerQueueConfig($queue_name);
         $this->worker_queues[$queue_name] = new WorkerQueue(
-            $this->getMessageQueue($queue_config),
+            $this->getMessageQueue("worker-{$queue_name}"),
             $this
         );
 
@@ -158,12 +156,12 @@ class QueueManager
     }
 
     /**
-     * @param  array  $queue_config
+     * @param  string $queue_name
      * @return MessageQueue
      */
-    private function getMessageQueue(array $queue_config)
+    private function getMessageQueue($queue_name)
     {
-        return $this->getMessageQueueFactory()->getQueue($queue_config);
+        return $this->getMessageQueueFactory()->getQueue($queue_name);
     }
 
     /**

--- a/src/Hodor/MessageQueue/Adapter/ConfigInterface.php
+++ b/src/Hodor/MessageQueue/Adapter/ConfigInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter;
+
+use Hodor\MessageQueue\Message;
+
+interface ConfigInterface
+{
+    /**
+     * @param string $queue_name
+     * @return array
+     */
+    public function getQueueConfig($queue_name);
+}

--- a/src/Hodor/MessageQueue/Adapter/FactoryInterface.php
+++ b/src/Hodor/MessageQueue/Adapter/FactoryInterface.php
@@ -5,14 +5,14 @@ namespace Hodor\MessageQueue\Adapter;
 interface FactoryInterface
 {
     /**
-     * @param array $queue_config
+     * @param string $queue_name
      * @return ConsumerInterface
      */
-    public function getConsumer(array $queue_config);
+    public function getConsumer($queue_name);
 
     /**
-     * @param array $queue_config
+     * @param string $queue_name
      * @return ProducerInterface
      */
-    public function getProducer(array $queue_config);
+    public function getProducer($queue_name);
 }

--- a/src/Hodor/MessageQueue/QueueFactory.php
+++ b/src/Hodor/MessageQueue/QueueFactory.php
@@ -3,10 +3,16 @@
 namespace Hodor\MessageQueue;
 
 use Hodor\MessageQueue\Adapter\Amqp\Factory;
+use Hodor\MessageQueue\Adapter\ConfigInterface;
 use Hodor\MessageQueue\Adapter\FactoryInterface;
 
 class QueueFactory
 {
+    /**
+     * @var ConfigInterface
+     */
+    private $config;
+
     /**
      * @var FactoryInterface
      */
@@ -23,20 +29,26 @@ class QueueFactory
     private $is_in_batch = false;
 
     /**
-     * @param array $queue_config
+     * @param ConfigInterface $config
+     */
+    public function __construct(ConfigInterface $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @param string $queue_name
      * @return Queue
      */
-    public function getQueue(array $queue_config)
+    public function getQueue($queue_name)
     {
-        $queue_name = $queue_config['queue_name'];
-
         if (isset($this->queues[$queue_name])) {
             return $this->queues[$queue_name];
         }
 
         $this->queues[$queue_name] = new Queue(
-            $this->getAdapterFactory()->getConsumer($queue_config),
-            $this->getAdapterFactory()->getProducer($queue_config)
+            $this->getAdapterFactory()->getConsumer($queue_name),
+            $this->getAdapterFactory()->getProducer($queue_name)
         );
         if ($this->is_in_batch) {
             $this->queues[$queue_name]->beginBatch();
@@ -78,7 +90,7 @@ class QueueFactory
             return $this->adapter_factory;
         }
 
-        $this->adapter_factory = new Factory();
+        $this->adapter_factory = new Factory($this->config);
 
         return $this->adapter_factory;
     }

--- a/tests/src/Hodor/MessageQueue/QueueFactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/QueueFactoryTest.php
@@ -14,7 +14,7 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $config_adapter = $this->getMock('\Hodor\MessageQueue\Adapter\Config');
+        $config_adapter = $this->getMock('\Hodor\MessageQueue\Adapter\ConfigInterface');
         $config_adapter->method('getQueueConfig')
             ->willReturn($this->queueConfigProvider()[0][0]);
 

--- a/tests/src/Hodor/MessageQueue/QueueFactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/QueueFactoryTest.php
@@ -3,25 +3,22 @@
 namespace Hodor\MessageQueue;
 
 use Exception;
+use Hodor\MessageQueue\Adapter\Config;
 use PHPUnit_Framework_TestCase;
 
 class QueueFactoryTest extends PHPUnit_Framework_TestCase
 {
-    /**
-     * @var array
-     */
-    private $config;
-
-    /**
-     * @var QueueFactory
-     */
     private $queue_factory;
 
     public function setUp()
     {
         parent::setUp();
 
-        $this->queue_factory = new QueueFactory();
+        $config_adapter = $this->getMock('\Hodor\MessageQueue\Adapter\Config');
+        $config_adapter->method('getQueueConfig')
+            ->willReturn($this->queueConfigProvider()[0][0]);
+
+        $this->queue_factory = new QueueFactory($config_adapter);
     }
 
     /**
@@ -32,7 +29,7 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf(
             '\Hodor\MessageQueue\Queue',
-            $this->queue_factory->getQueue($config)
+            $this->queue_factory->getQueue('worker-default')
         );
     }
 
@@ -43,8 +40,8 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
     public function testQueueIsReusedIfReferredToMultipleTimes(array $config)
     {
         $this->assertSame(
-            $this->queue_factory->getQueue($config),
-            $this->queue_factory->getQueue($config)
+            $this->queue_factory->getQueue('worker-default'),
+            $this->queue_factory->getQueue('worker-default')
         );
     }
 


### PR DESCRIPTION
Rather than passing in an entire config each time a message
queue needs to be retrieved, pass a config object to the
factory and then allow message queues to be retrieved by name
