### PR TITLE
Ensure RabbitMQ connection happens just-in-time

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Amqp/Channel.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Channel.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Amqp;
+
+use PhpAmqpLib\Channel\AMQPChannel;
+
+class Channel
+{
+    /**
+     * @var AMQPChannel
+     */
+    private $amqp_channel;
+
+    /**
+     * @var array
+     */
+    private $queue_config;
+
+    /**
+     * @param AMQPChannel $amqp_channel
+     * @param array $queue_config
+     */
+    public function __construct(AMQPChannel $amqp_channel, array $queue_config)
+    {
+        $this->amqp_channel = $amqp_channel;
+        $this->queue_config = $queue_config;
+    }
+
+    /**
+     * @return AMQPChannel
+     */
+    public function getAmqpChannel()
+    {
+        return $this->amqp_channel;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getQueueName()
+    {
+        return $this->queue_config['queue_name'];
+    }
+}

--- a/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Amqp;
+
+use Hodor\MessageQueue\Adapter\ConfigInterface;
+use Hodor\MessageQueue\Adapter\ConsumerInterface;
+use Hodor\MessageQueue\Adapter\FactoryInterface;
+use Hodor\MessageQueue\Adapter\ProducerInterface;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AbstractConnection;
+
+class ChannelFactory
+{
+    /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
+     * @var AbstractConnection[]
+     */
+    private $connections = [];
+
+    /**
+     * @var AMQPChannel[]
+     */
+    private $channels = [];
+
+    /**
+     * @param ConfigInterface $config
+     */
+    public function __construct(ConfigInterface $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @param  string $queue_key
+     * @return AMQPChannel
+     */
+    public function getChannel($queue_key)
+    {
+        if (isset($this->channels[$queue_key])) {
+            return $this->channels[$queue_key];
+        }
+
+        $queue_config = $this->config->getQueueConfig($queue_key);
+        $connection = $this->getAmqpConnection($queue_config);
+
+        $amqp_channel = $connection->channel();
+
+        $amqp_channel->queue_declare(
+            $queue_config['queue_name'],
+            false,
+            ($is_durable = true),
+            false,
+            false
+        );
+        $amqp_channel->basic_qos(
+            null,
+            $queue_config['fetch_count'],
+            null
+        );
+
+        $this->channels[$queue_key] = new Channel($amqp_channel, $queue_config);
+
+        return $this->channels[$queue_key];
+    }
+
+    /**
+     * @param  array  $queue_config
+     * @return AbstractConnection
+     */
+    private function getAmqpConnection(array $queue_config)
+    {
+        $connection_key = $this->getConnectionKey($queue_config);
+
+        if (isset($this->connections[$connection_key])) {
+            return $this->connections[$connection_key];
+        }
+
+        $connection_class = '\PhpAmqpLib\Connection\AMQPConnection';
+        if (isset($queue_config['connection_type'])
+            && 'socket' === $queue_config['connection_type']
+        ) {
+            $connection_class = '\PhpAmqpLib\Connection\AMQPSocketConnection';
+        }
+
+        $this->connections[$connection_key] = new $connection_class(
+            $queue_config['host'],
+            $queue_config['port'],
+            $queue_config['username'],
+            $queue_config['password']
+        );
+
+        return $this->connections[$connection_key];
+    }
+
+    /**
+     * @param  array  $queue_config
+     * @return string
+     */
+    private function getConnectionKey(array $queue_config)
+    {
+        return implode(
+            '::',
+            [
+                $queue_config['host'],
+                $queue_config['port'],
+                $queue_config['username'],
+                $queue_config['queue_name'],
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Issue #14
- Move the AMQPConnection and AMQPChannel to a ChannelFactory
- Pass the ChannelFactory into the Consumer & Producer and let
  them request the AMQPChannel (and indirectly AMQPConnection)
  when they need it
