### PR TITLE
Move phpmig.php services to Container class

### DIFF
--- a/phpmig.php
+++ b/phpmig.php
@@ -1,52 +1,8 @@
 <?php
 
-use Hodor\Config\LoaderFactory as ConfigFactory;
-use Hodor\Database\AdapterFactory as DbFactory;
+use Hodor\Database\Phpmig\Container;
 
-$container = new Pimple();
-
-$container['hodor.config.factory'] = $container->share(function () {
-    return new ConfigFactory();
-});
-
-$container['hodor.config'] = $container->share(function (Pimple $container) {
-    $config_path = getenv('HODOR_CONFIG');
-    if (!$config_path) {
-        throw new Exception(
-            "Please provide a config file using a 'HODOR_CONFIG' environment variable."
-        );
-    }
-
-    return $container['hodor.config.factory']->loadFromFile(getenv('HODOR_CONFIG'));
-});
-
-$container['hodor.database.config'] = $container->share(function (Pimple $container) {
-    return $container['hodor.config']->getDatabaseConfig();
-});
-
-$container['hodor.database.factory'] = $container->share(function (Pimple $container) {
-    return new DbFactory($container['hodor.database.config']);
-});
-
-$container['hodor.database'] = $container->share(function (Pimple $container) {
-    $db_factory = $container['hodor.database.factory'];
-    $db_config = $container['hodor.database.config'];
-
-    return $db_factory->getAdapter($db_config['type']);
-});
-
-$container['phpmig.adapter'] = $container->share(function (Pimple $container) {
-    $db_adapter = $container['hodor.database'];
-
-    return $db_adapter->getPhpmigAdapter();
-});
-
-$container['phpmig.migrations_path'] = $container->share(function (Pimple $container) {
-    return $container['phpmig.adapter']->getMigrationsPath();
-});
-
-$container['phpmig.migrations_template_path'] = $container->share(function (Pimple $container) {
-    return __DIR__.'/src/Hodor/Database/Phpmig/MigrationTemplate.php';
-});
+$container = new Container();
+$container->addDefaultServices();
 
 return $container;

--- a/src/Hodor/Database/Phpmig/Container.php
+++ b/src/Hodor/Database/Phpmig/Container.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Hodor\Database\Phpmig;
+
+use Exception;
+use Hodor\Config\LoaderFactory as ConfigFactory;
+use Hodor\Database\AdapterFactory as DbFactory;
+use Pimple;
+
+class Container extends Pimple
+{
+    public function addDefaultServices()
+    {
+        $this['hodor.config.factory'] = $this->share(
+            function () {
+                return new ConfigFactory();
+            }
+        );
+
+        $this['hodor.config'] = $this->share(
+            function (Pimple $container) {
+                $config_path = getenv('HODOR_CONFIG');
+                if (!$config_path) {
+                    throw new Exception(
+                        "Please provide a config file using a 'HODOR_CONFIG' environment variable."
+                    );
+                }
+
+                return $container['hodor.config.factory']->loadFromFile(getenv('HODOR_CONFIG'));
+            }
+        );
+
+        $this['hodor.database.config'] = $this->share(
+            function (Pimple $container) {
+                return $container['hodor.config']->getDatabaseConfig();
+            }
+        );
+
+        $this['hodor.database.factory'] = $this->share(
+            function (Pimple $container) {
+                return new DbFactory($container['hodor.database.config']);
+            }
+        );
+
+        $this['hodor.database'] = $this->share(
+            function (Pimple $container) {
+                $db_factory = $container['hodor.database.factory'];
+                $db_config = $container['hodor.database.config'];
+
+                return $db_factory->getAdapter($db_config['type']);
+            }
+        );
+
+        $this['phpmig.adapter'] = $this->share(
+            function (Pimple $container) {
+                $db_adapter = $container['hodor.database'];
+
+                return $db_adapter->getPhpmigAdapter();
+            }
+        );
+
+        $this['phpmig.migrations_path'] = $this->share(
+            function (Pimple $container) {
+                return $container['phpmig.adapter']->getMigrationsPath();
+            }
+        );
+
+        $this['phpmig.migrations_template_path'] = $this->share(
+            function (Pimple $container) {
+                return __DIR__ . '/MigrationTemplate.php';
+            }
+        );
+    }
+}


### PR DESCRIPTION
Having a reusable Container class will allow for customized
database migration CLI commands to be built
