### PR TITLE
Add getAdapterFactory() to MQ ConfigInterface

### DIFF
--- a/src/Hodor/JobQueue/Config.php
+++ b/src/Hodor/JobQueue/Config.php
@@ -3,6 +3,7 @@
 namespace Hodor\JobQueue;
 
 use Exception;
+use Hodor\MessageQueue\Adapter\Amqp\Factory;
 use Hodor\MessageQueue\Adapter\ConfigInterface;
 
 class Config implements ConfigInterface
@@ -174,6 +175,14 @@ class Config implements ConfigInterface
     public function getWorkerQueueNames()
     {
         return array_keys($this->getOption('worker_queues'));
+    }
+
+    /**
+     * @return Factory
+     */
+    public function getAdapterFactory()
+    {
+        return new Factory($this);
     }
 
     /**

--- a/src/Hodor/MessageQueue/Adapter/ConfigInterface.php
+++ b/src/Hodor/MessageQueue/Adapter/ConfigInterface.php
@@ -7,6 +7,11 @@ use Hodor\MessageQueue\Message;
 interface ConfigInterface
 {
     /**
+     * @return FactoryInterface
+     */
+    public function getAdapterFactory();
+
+    /**
      * @param string $queue_name
      * @return array
      */

--- a/src/Hodor/MessageQueue/QueueFactory.php
+++ b/src/Hodor/MessageQueue/QueueFactory.php
@@ -2,7 +2,6 @@
 
 namespace Hodor\MessageQueue;
 
-use Hodor\MessageQueue\Adapter\Amqp\Factory;
 use Hodor\MessageQueue\Adapter\ConfigInterface;
 use Hodor\MessageQueue\Adapter\FactoryInterface;
 
@@ -82,7 +81,7 @@ class QueueFactory
     }
 
     /**
-     * @return Factory
+     * @return FactoryInterface
      */
     private function getAdapterFactory()
     {
@@ -90,7 +89,7 @@ class QueueFactory
             return $this->adapter_factory;
         }
 
-        $this->adapter_factory = new Factory($this->config);
+        $this->adapter_factory = $this->config->getAdapterFactory();
 
         return $this->adapter_factory;
     }

--- a/tests/src/Hodor/MessageQueue/QueueFactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/QueueFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Hodor\MessageQueue;
 
 use Exception;
+use Hodor\MessageQueue\Adapter\Amqp\Factory;
 use Hodor\MessageQueue\Adapter\Config;
 use PHPUnit_Framework_TestCase;
 
@@ -15,6 +16,8 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
         parent::setUp();
 
         $config_adapter = $this->getMock('\Hodor\MessageQueue\Adapter\ConfigInterface');
+        $config_adapter->method('getAdapterFactory')
+            ->willReturn(new Factory($config_adapter));
         $config_adapter->method('getQueueConfig')
             ->willReturn($this->queueConfigProvider());
 


### PR DESCRIPTION
We need a way to configure which adapter factory is used
by the queue factory
