### PR TITLE
Append buffered_job_id and job name to process title

### DIFF
--- a/src/Hodor/JobQueue/WorkerQueue.php
+++ b/src/Hodor/JobQueue/WorkerQueue.php
@@ -62,6 +62,11 @@ class WorkerQueue
             $content = $message->getContent();
             $name = $content['name'];
             $params = $content['params'];
+            $meta = $content['meta'];
+
+            $title = implode(" ", $_SERVER['argv']) . " ({$meta['buffered_job_id']}:{$name})";
+            cli_set_process_title($title);
+
             call_user_func($job_runner, $name, $params);
 
             $superqueue = $this->queue_manager->getSuperqueue();


### PR DESCRIPTION
Having the buffered_job_id and job name in the title
allows for long-running jobs to be identified while
they are still running
