### PR TITLE
Support handling multiple jobs per buffer/worker process

### DIFF
--- a/config/dist/config.dist.php
+++ b/config/dist/config.dist.php
@@ -17,15 +17,17 @@ return [
         'connection_type' => 'stream',
     ],
     'buffer_queue_defaults' => [
-        'queue_prefix'         => 'hodor-buffer-',
-        'bufferers_per_server' => 10,
-        'superqueuer'          => 'default',
+        'queue_prefix'             => 'hodor-buffer-',
+        'bufferers_per_server'     => 10,
+        'superqueuer'              => 'default',
+        'max_messages_per_consume' => 1,
     ],
     'buffer_queues' => [
         'default' => [],
     ],
     'worker_queue_defaults' => [
-        'queue_prefix' => 'hodor-worker-',
+        'queue_prefix'             => 'hodor-worker-',
+        'max_messages_per_consume' => 1,
     ],
     'worker_queues' => [
         'default' => [

--- a/src/Hodor/JobQueue/BufferQueue.php
+++ b/src/Hodor/JobQueue/BufferQueue.php
@@ -55,8 +55,6 @@ class BufferQueue
         $this->message_queue->consume(function ($message) {
             $superqueue = $this->queue_manager->getSuperqueue();
             $superqueue->bufferJobFromBufferQueueToDatabase($message);
-
-            exit(0);
         });
     }
 }

--- a/src/Hodor/JobQueue/WorkerQueue.php
+++ b/src/Hodor/JobQueue/WorkerQueue.php
@@ -71,8 +71,6 @@ class WorkerQueue
 
             $superqueue = $this->queue_manager->getSuperqueue();
             $superqueue->markJobAsSuccessful($message, $start_time);
-
-            exit(0);
         });
     }
 }

--- a/src/Hodor/MessageQueue/Adapter/Amqp/Channel.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Channel.php
@@ -41,4 +41,20 @@ class Channel
     {
         return $this->queue_config['queue_name'];
     }
+
+    /**
+     * @return int
+     */
+    public function getMaxMessagesPerConsume()
+    {
+        return $this->queue_config['max_messages_per_consume'];
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxTimePerConsume()
+    {
+        return $this->queue_config['max_time_per_consume'];
+    }
 }

--- a/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
@@ -76,8 +76,10 @@ class ChannelFactory
     {
         $queue_config = array_merge(
             [
-                'fetch_count'     => 1,
-                'connection_type' => 'stream',
+                'fetch_count'              => 1,
+                'connection_type'          => 'stream',
+                'max_messages_per_consume' => 1,
+                'max_time_per_consume'     => 600,
             ],
             $this->config->getQueueConfig($queue_key)
         );

--- a/src/Hodor/MessageQueue/Adapter/Amqp/Consumer.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Consumer.php
@@ -53,9 +53,23 @@ class Consumer implements ConsumerInterface
             }
         );
 
-        while (count($amqp_channel->callbacks)) {
-            $amqp_channel->wait();
-        }
+        $amqp_channel->wait();
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxMessagesPerConsume()
+    {
+        return $this->getChannel()->getMaxMessagesPerConsume();
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxTimePerConsume()
+    {
+        return $this->getChannel()->getMaxTimePerConsume();
     }
 
     /**

--- a/src/Hodor/MessageQueue/Adapter/ConsumerInterface.php
+++ b/src/Hodor/MessageQueue/Adapter/ConsumerInterface.php
@@ -10,4 +10,14 @@ interface ConsumerInterface
      * @param callable $callback
      */
     public function consumeMessage(callable $callback);
+
+    /**
+     * @return int
+     */
+    public function getMaxMessagesPerConsume();
+
+    /**
+     * @return int
+     */
+    public function getMaxTimePerConsume();
 }

--- a/src/Hodor/MessageQueue/Queue.php
+++ b/src/Hodor/MessageQueue/Queue.php
@@ -60,7 +60,16 @@ class Queue
      */
     public function consume(callable $callback)
     {
-        $this->consumer->consumeMessage($callback);
+        $start_time = time();
+        $message_count = 0;
+
+        $max_message_count = $this->consumer->getMaxMessagesPerConsume();
+        $max_time = $this->consumer->getMaxTimePerConsume();
+
+        do {
+            $this->consumer->consumeMessage($callback);
+            ++$message_count;
+        } while ($message_count < $max_message_count && time() - $start_time <= $max_time);
     }
 
     public function beginBatch()


### PR DESCRIPTION
Issue #8

Rather than exiting after every buffer/worker process
consumes a job, let the MQ consumer decide when to exit
and use 'max_messages_per_consume' to allow devs to
control how many messages per buffer/worker process
to handle before exiting.
