### PR TITLE
Add MQ testing config adapter

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Testing/Config.php
+++ b/src/Hodor/MessageQueue/Adapter/Testing/Config.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Testing;
+
+use Hodor\MessageQueue\Adapter\ConfigInterface;
+use Hodor\MessageQueue\Adapter\FactoryInterface;
+use OutOfBoundsException;
+
+class Config implements ConfigInterface
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $adapter_factory;
+
+    /**
+     * @var array
+     */
+    private $queues = [];
+
+    /**
+     * @param FactoryInterface $adapter_factory
+     */
+    public function __construct(FactoryInterface $adapter_factory)
+    {
+        $this->adapter_factory = $adapter_factory;
+    }
+
+    /**
+     * @return FactoryInterface
+     */
+    public function getAdapterFactory()
+    {
+        return $this->adapter_factory;
+    }
+
+    /**
+     * @param string $queue_key
+     * @param array  $config
+     */
+    public function addQueueConfig($queue_key, array $config)
+    {
+        $this->queues[$queue_key] = $config;
+    }
+
+    /**
+     * @param string $queue_key
+     * @return array
+     */
+    public function getQueueConfig($queue_key)
+    {
+        if (empty($this->queues[$queue_key])) {
+            throw new OutOfBoundsException("Queue with '{$queue_key}' not found.");
+        }
+
+        return $this->queues[$queue_key];
+    }
+}

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/ConfigTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/ConfigTest.php
@@ -33,6 +33,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Hodor\MessageQueue\Adapter\Testing\Config::addQueueConfig
      * @covers Hodor\MessageQueue\Adapter\Testing\Config::getQueueConfig
      * @dataProvider queueConfigProvider
      * @param string $queue_key

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/ConfigTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/ConfigTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Testing;
+
+use Hodor\MessageQueue\Adapter\FactoryInterface;
+use PHPUnit_Framework_TestCase;
+
+class ConfigTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers Hodor\MessageQueue\Adapter\Testing\Config::__construct
+     * @covers Hodor\MessageQueue\Adapter\Testing\Config::getAdapterFactory
+     */
+    public function testAdapterFactoryReturnedIsSameProvidedToConstructor()
+    {
+        $adapter_factory = $this->getAdapterFactoryMock();
+        $config = new Config($adapter_factory);
+
+        $this->assertSame($adapter_factory, $config->getAdapterFactory());
+    }
+
+    /**
+     * @covers Hodor\MessageQueue\Adapter\Testing\Config::getQueueConfig
+     * @expectedException \OutOfBoundsException
+     * @dataProvider queueConfigProvider
+     * @param string $queue_key
+     */
+    public function testRetrievingUndefinedQueueThrowsAnException($queue_key)
+    {
+        $config = new Config($this->getAdapterFactoryMock());
+
+        $config->getQueueConfig($queue_key);
+    }
+
+    /**
+     * @covers Hodor\MessageQueue\Adapter\Testing\Config::getQueueConfig
+     * @dataProvider queueConfigProvider
+     * @param string $queue_key
+     * @param array $queue_config
+     */
+    public function testAddedQueueConfigCanBeRetrieved($queue_key, array $queue_config)
+    {
+        $config = new Config($this->getAdapterFactoryMock());
+
+        $config->addQueueConfig($queue_key, $queue_config);
+        $this->assertEquals($queue_config, $config->getQueueConfig($queue_key));
+    }
+
+    public function queueConfigProvider()
+    {
+        return [
+            ['default-queue-key', ['queue_name' => 'default-queue-name', 'host' => 'localhost']],
+            [uniqid(), ['queue_name' => uniqid(), 'host' => uniqid()]],
+        ];
+    }
+
+    /**
+     * @return FactoryInterface
+     */
+    private function getAdapterFactoryMock()
+    {
+        return $this->getMock('Hodor\MessageQueue\Adapter\FactoryInterface');
+    }
+}


### PR DESCRIPTION
The config adapter will be used for testing Hodor as well as
potentially testing application integrations with Hodor
