### PR TITLE
Wrap AMQPConnection in Connection wrapper class

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
@@ -18,7 +18,7 @@ class ChannelFactory
     private $config;
 
     /**
-     * @var AbstractConnection[]
+     * @var Connection[]
      */
     private $connections = [];
 
@@ -102,22 +102,12 @@ class ChannelFactory
         $connection_key = $this->getConnectionKey($queue_config);
 
         if (isset($this->connections[$connection_key])) {
-            return $this->connections[$connection_key];
+            return $this->connections[$connection_key]->getAmqpConnection();
         }
 
-        $connection_class = '\PhpAmqpLib\Connection\AMQPConnection';
-        if ('socket' === $queue_config['connection_type']) {
-            $connection_class = '\PhpAmqpLib\Connection\AMQPSocketConnection';
-        }
+        $this->connections[$connection_key] = new Connection($queue_config);
 
-        $this->connections[$connection_key] = new $connection_class(
-            $queue_config['host'],
-            $queue_config['port'],
-            $queue_config['username'],
-            $queue_config['password']
-        );
-
-        return $this->connections[$connection_key];
+        return $this->connections[$connection_key]->getAmqpConnection();
     }
 
     /**

--- a/src/Hodor/MessageQueue/Adapter/Amqp/Connection.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Connection.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Amqp;
+
+use LogicException;
+use PhpAmqpLib\Connection\AbstractConnection;
+
+class Connection
+{
+    /**
+     * @var array
+     */
+    private $connection_config;
+
+    /**
+     * @var AbstractConnection
+     */
+    private $amqp_connection;
+
+    /**
+     * @param array $connection_config
+     */
+    public function __construct(array $connection_config)
+    {
+        $this->connection_config = array_merge(
+            ['connection_type' => 'stream'],
+            $connection_config
+        );
+
+        $this->validateConfig();
+    }
+
+    public function __destruct()
+    {
+        if (!$this->amqp_connection || !$this->amqp_connection->isConnected()) {
+            return;
+        }
+
+        $this->amqp_connection->close();
+    }
+
+    /**
+     * @return AbstractConnection
+     */
+    public function getAmqpConnection()
+    {
+        if ($this->amqp_connection) {
+            return $this->amqp_connection;
+        }
+
+        $connection_class = '\PhpAmqpLib\Connection\AMQPStreamConnection';
+        if ('socket' === $this->connection_config['connection_type']) {
+            $connection_class = '\PhpAmqpLib\Connection\AMQPSocketConnection';
+        }
+
+        $this->amqp_connection = new $connection_class(
+            $this->connection_config['host'],
+            $this->connection_config['port'],
+            $this->connection_config['username'],
+            $this->connection_config['password']
+        );
+
+        return $this->amqp_connection;
+    }
+
+    /**
+     * @throws LogicException
+     */
+    private function validateConfig()
+    {
+        foreach (['host', 'port', 'username', 'password'] as $key) {
+            if (empty($this->connection_config[$key])) {
+                throw new LogicException("The connection config must contain a '{$key}' config.");
+            }
+        }
+    }
+}

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConnectionTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConnectionTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Amqp;
+
+use PHPUnit_Framework_TestCase;
+
+class ConnectionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Connection::__construct
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Connection::<private>
+     * @dataProvider provideConnectionConfigMissingARequiredField
+     * @expectedException \LogicException
+     * @param array $connection_config
+     */
+    public function testExceptionIsThrownIfARequiredFieldIsMissing(array $connection_config)
+    {
+        new Connection($connection_config);
+    }
+
+    /**
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Connection::__construct
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Connection::<private>
+     */
+    public function testConnectionCanBeInstantiatedWithoutError()
+    {
+        $this->assertInstanceOf(
+            'Hodor\MessageQueue\Adapter\Amqp\Connection',
+            new Connection($this->getRabbitCredentials())
+        );
+    }
+
+    /**
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Connection::__destruct
+     * @dataProvider provideConnectionsOfDifferentTypes
+     * @param Connection
+     */
+    public function testConnectionCanBeDestroyedWithoutUsingAmqpConnection(Connection $connection)
+    {
+        $connection = new Connection($this->getRabbitCredentials());
+        unset($connection);
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Connection::__construct
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Connection::getAmqpConnection
+     */
+    public function testAmqpStreamConnectionIsUsedByDefault()
+    {
+        $connection = new Connection($this->getRabbitCredentials());
+        $this->assertInstanceOf(
+            'PhpAmqpLib\Connection\AMQPStreamConnection',
+            $connection->getAmqpConnection()
+        );
+        $this->assertTrue($connection->getAmqpConnection()->isConnected());
+    }
+
+    /**
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Connection::__construct
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Connection::getAmqpConnection
+     */
+    public function testAmqpSocketConnectionCanBeRequested()
+    {
+        $connection_config = $this->getRabbitCredentials();
+        $connection_config['connection_type'] = 'socket';
+
+        $connection = new Connection($connection_config);
+        $this->assertInstanceOf(
+            'PhpAmqpLib\Connection\AMQPSocketConnection',
+            $connection->getAmqpConnection()
+        );
+        $this->assertTrue($connection->getAmqpConnection()->isConnected());
+    }
+
+    /**
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Connection::__destruct
+     */
+    public function testStreamConnectionIsClosedAfterDestroyingConnection()
+    {
+        $connection = new Connection($this->getRabbitCredentials());
+
+        $amqp_connection = $connection->getAmqpConnection();
+
+        $this->assertTrue($amqp_connection->isConnected());
+        unset($connection);
+        $this->assertFalse($amqp_connection->isConnected());
+    }
+
+    /**
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Connection::__destruct
+     */
+    public function testSocketConnectionIsClosedAfterDestroyingConnection()
+    {
+        $connection_config = $this->getRabbitCredentials();
+        $connection_config['connection_type'] = 'socket';
+        $connection = new Connection($connection_config);
+
+        $amqp_connection = $connection->getAmqpConnection();
+
+        $this->assertTrue($amqp_connection->isConnected());
+        unset($connection);
+        $this->assertFalse($amqp_connection->isConnected());
+    }
+
+    /**
+     * @return array
+     */
+    public function provideConnectionConfigMissingARequiredField()
+    {
+        $rabbit_credentials = $this->getRabbitCredentials();
+
+        $required_fields = [
+            'host'     => $rabbit_credentials['host'],
+            'port'     => $rabbit_credentials['port'],
+            'username' => $rabbit_credentials['username'],
+            'password' => $rabbit_credentials['password'],
+        ];
+
+        $connection_configs = [];
+        foreach ($required_fields as $field_to_remove => $value) {
+            $connection_config = $required_fields;
+            unset($connection_config[$field_to_remove]);
+
+            $connection_configs[] = [$connection_config];
+        }
+
+        return $connection_configs;
+    }
+
+    public function provideConnectionsOfDifferentTypes()
+    {
+        $rabbit_credentials = $this->getRabbitCredentials();
+
+        $stream_config = $rabbit_credentials;
+
+        $socket_config = $rabbit_credentials;
+        $socket_config['connection_type'] = 'socket';
+
+        return [
+            [new Connection($stream_config)],
+            [new Connection($socket_config)],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function getRabbitCredentials()
+    {
+        $config = require __DIR__ . '/../../../../../../config/config.test.php';
+        $rabbit_credentials = $config['test']['rabbitmq'];
+
+        return [
+            'host'     => $rabbit_credentials['host'],
+            'port'     => $rabbit_credentials['port'],
+            'username' => $rabbit_credentials['username'],
+            'password' => $rabbit_credentials['password'],
+        ];
+    }
+}


### PR DESCRIPTION
We need to be able to manually close out the AMQPConnection
when the Connection class is destructed so unit tests are not
hogging a ton of connections and causing segmentation faults
(really!!! it was happening when trying to test the channel factory)

https://github.com/php-amqplib/php-amqplib/issues/261
