### PR TITLE
Move AMQP channel generation to Channel class

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Amqp/Channel.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Channel.php
@@ -2,14 +2,15 @@
 
 namespace Hodor\MessageQueue\Adapter\Amqp;
 
+use LogicException;
 use PhpAmqpLib\Channel\AMQPChannel;
 
 class Channel
 {
     /**
-     * @var AMQPChannel
+     * @var Connection
      */
-    private $amqp_channel;
+    private $connection;
 
     /**
      * @var array
@@ -17,13 +18,27 @@ class Channel
     private $queue_config;
 
     /**
-     * @param AMQPChannel $amqp_channel
+     * @var AMQPChannel
+     */
+    private $amqp_channel;
+
+    /**
+     * @param Connection $connection
      * @param array $queue_config
      */
-    public function __construct(AMQPChannel $amqp_channel, array $queue_config)
+    public function __construct(Connection $connection, array $queue_config)
     {
-        $this->amqp_channel = $amqp_channel;
-        $this->queue_config = $queue_config;
+        $this->connection = $connection;
+        $this->queue_config = array_merge(
+            [
+                'fetch_count'              => 1,
+                'max_messages_per_consume' => 1,
+                'max_time_per_consume'     => 600,
+            ],
+            $queue_config
+        );
+
+        $this->validateConfig();
     }
 
     /**
@@ -31,6 +46,25 @@ class Channel
      */
     public function getAmqpChannel()
     {
+        if ($this->amqp_channel) {
+            return $this->amqp_channel;
+        }
+
+        $this->amqp_channel = $this->connection->getAmqpConnection()->channel();
+
+        $this->amqp_channel->queue_declare(
+            $this->queue_config['queue_name'],
+            false,
+            ($is_durable = true),
+            false,
+            false
+        );
+        $this->amqp_channel->basic_qos(
+            null,
+            $this->queue_config['fetch_count'],
+            null
+        );
+
         return $this->amqp_channel;
     }
 
@@ -56,5 +90,17 @@ class Channel
     public function getMaxTimePerConsume()
     {
         return $this->queue_config['max_time_per_consume'];
+    }
+
+    /**
+     * @throws LogicException
+     */
+    private function validateConfig()
+    {
+        foreach (['queue_name'] as $key) {
+            if (empty($this->queue_config[$key])) {
+                throw new LogicException("The connection config must contain a '{$key}' config.");
+            }
+        }
     }
 }

--- a/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
@@ -46,24 +46,9 @@ class ChannelFactory
         }
 
         $queue_config = $this->getQueueConfig($queue_key);
-        $connection = $this->getAmqpConnection($queue_config);
+        $connection = $this->getConnection($queue_config);
 
-        $amqp_channel = $connection->channel();
-
-        $amqp_channel->queue_declare(
-            $queue_config['queue_name'],
-            false,
-            ($is_durable = true),
-            false,
-            false
-        );
-        $amqp_channel->basic_qos(
-            null,
-            $queue_config['fetch_count'],
-            null
-        );
-
-        $this->channels[$queue_key] = new Channel($amqp_channel, $queue_config);
+        $this->channels[$queue_key] = new Channel($connection, $queue_config);
 
         return $this->channels[$queue_key];
     }
@@ -95,19 +80,19 @@ class ChannelFactory
 
     /**
      * @param  array  $queue_config
-     * @return AbstractConnection
+     * @return Connection
      */
-    private function getAmqpConnection(array $queue_config)
+    private function getConnection(array $queue_config)
     {
         $connection_key = $this->getConnectionKey($queue_config);
 
         if (isset($this->connections[$connection_key])) {
-            return $this->connections[$connection_key]->getAmqpConnection();
+            return $this->connections[$connection_key];
         }
 
         $this->connections[$connection_key] = new Connection($queue_config);
 
-        return $this->connections[$connection_key]->getAmqpConnection();
+        return $this->connections[$connection_key];
     }
 
     /**

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ChannelTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ChannelTest.php
@@ -8,17 +8,56 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @covers Hodor\MessageQueue\Adapter\Amqp\Channel::__construct
-     * @covers Hodor\MessageQueue\Adapter\Amqp\Channel::getAmqpChannel
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Channel::<private>
+     * @dataProvider provideQueueConfigMissingARequiredField
+     * @expectedException \LogicException
+     * @param array $queue_config
      */
-    public function testAmqpChannelPassedToConstructorIsTheSameRetrieved()
+    public function testExceptionIsThrownIfARequiredFieldIsMissing(array $queue_config)
     {
-        $amqp_channel = $this
-            ->getMockBuilder('PhpAmqpLib\Channel\AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $channel = new Channel($amqp_channel, []);
+        new Channel($this->getMockConnection(), $queue_config);
+    }
 
-        $this->assertSame($amqp_channel, $channel->getAmqpChannel());
+    /**
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Channel::__construct
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Channel::<private>
+     */
+    public function testConnectionCanBeInstantiatedWithoutError()
+    {
+        $connection = $this->getMockConnection();
+        $channel = new Channel($connection, ['queue_name' => uniqid()]);
+
+        $this->assertInstanceOf('Hodor\MessageQueue\Adapter\Amqp\Channel', $channel);
+    }
+
+    /**
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Channel::__construct
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Channel::getAmqpChannel
+     * @dataProvider provideQueueList
+     * @param array $queues
+     */
+    public function testAmqpChannelsCanBeRetrieved(array $queues)
+    {
+        foreach ($queues as $queue_key => $queue_config) {
+            $connection = new Connection($queue_config);
+            $channel = new Channel($connection, $queue_config);
+            $this->assertInstanceOf('PhpAmqpLib\Channel\AMQPChannel', $channel->getAmqpChannel());
+        }
+    }
+
+    /**
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Channel::__construct
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Channel::getAmqpChannel
+     * @dataProvider provideQueueList
+     * @param array $queues
+     */
+    public function testAmqpChannelsCanBeReused(array $queues)
+    {
+        foreach ($queues as $queue_key => $queue_config) {
+            $connection = new Connection($queue_config);
+            $channel = new Channel($connection, $queue_config);
+            $this->assertSame($channel->getAmqpChannel(), $channel->getAmqpChannel());
+        }
     }
 
     /**
@@ -29,11 +68,8 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     {
         $queue_name = uniqid();
 
-        $amqp_channel = $this
-            ->getMockBuilder('PhpAmqpLib\Channel\AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $channel = new Channel($amqp_channel, ['queue_name' => $queue_name]);
+        $connection = $this->getMockConnection();
+        $channel = new Channel($connection, ['queue_name' => $queue_name]);
 
         $this->assertEquals($queue_name, $channel->getQueueName());
     }
@@ -46,11 +82,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     {
         $max_messages = rand(1, 100);
 
-        $amqp_channel = $this
-            ->getMockBuilder('PhpAmqpLib\Channel\AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $channel = new Channel($amqp_channel, ['max_messages_per_consume' => $max_messages]);
+        $connection = $this->getMockConnection();
+        $channel = new Channel($connection, [
+            'queue_name'               => uniqid(),
+            'max_messages_per_consume' => $max_messages,
+        ]);
 
         $this->assertEquals($max_messages, $channel->getMaxMessagesPerConsume());
     }
@@ -63,12 +99,81 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     {
         $max_time = rand(1, 100);
 
-        $amqp_channel = $this
-            ->getMockBuilder('PhpAmqpLib\Channel\AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $channel = new Channel($amqp_channel, ['max_time_per_consume' => $max_time]);
+        $connection = $this->getMockConnection();
+        $channel = new Channel($connection, [
+            'queue_name'           => uniqid(),
+            'max_time_per_consume' => $max_time
+        ]);
 
         $this->assertEquals($max_time, $channel->getMaxTimePerConsume());
+    }
+
+    /**
+     * @return array
+     */
+    public function provideQueueConfigMissingARequiredField()
+    {
+        $rabbit_credentials = $this->getRabbitCredentials();
+
+        $required_fields = [
+            'queue_name' => uniqid(),
+        ];
+
+        $queue_configs = [];
+        foreach ($required_fields as $field_to_remove => $value) {
+            $queue_config = $required_fields;
+            unset($queue_config[$field_to_remove]);
+
+            $queue_configs[] = [$queue_config];
+        }
+
+        return $queue_configs;
+    }
+
+    public function provideQueueList()
+    {
+        $rabbit_credentials = $this->getRabbitCredentials();
+
+        return [
+            [
+                [
+                    'fast_jobs' => [
+                        'host'       => $rabbit_credentials['host'],
+                        'port'       => $rabbit_credentials['port'],
+                        'username'   => $rabbit_credentials['username'],
+                        'password'   => $rabbit_credentials['password'],
+                        'queue_name' => $rabbit_credentials['queue_prefix'] . uniqid(),
+                    ],
+                    'slow_jobs' => [
+                        'host'       => $rabbit_credentials['host'],
+                        'port'       => $rabbit_credentials['port'],
+                        'username'   => $rabbit_credentials['username'],
+                        'password'   => $rabbit_credentials['password'],
+                        'queue_name' => $rabbit_credentials['queue_prefix'] . uniqid(),
+                    ],
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @return Connection
+     */
+    private function getMockConnection()
+    {
+        /**
+         * @var Connection $connection
+         */
+        return $this
+            ->getMockBuilder('Hodor\MessageQueue\Adapter\Amqp\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    private function getRabbitCredentials()
+    {
+        $config = require __DIR__ . '/../../../../../../config/config.test.php';
+
+        return  $config['test']['rabbitmq'];
     }
 }


### PR DESCRIPTION
By having the AMQP channel generated in the Channel class
we can cleanly pass in the Connection to the Channel class.
Passing in the Connection to the Channel means that so long
as the Channel exists, the destructor of the Connection will
not be called and the Channel's AMQP Connection should be
maintained.
