### PR TITLE
Allow explicit disconnect of connection

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Amqp/Connection.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Connection.php
@@ -32,11 +32,20 @@ class Connection
 
     public function __destruct()
     {
-        if (!$this->amqp_connection || !$this->amqp_connection->isConnected()) {
+        $this->disconnect();
+    }
+
+    public function disconnect()
+    {
+        if (!$this->amqp_connection) {
             return;
         }
 
-        $this->amqp_connection->close();
+        if ($this->amqp_connection->isConnected()) {
+            $this->amqp_connection->close();
+        }
+
+        $this->amqp_connection = null;
     }
 
     /**

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConnectionTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConnectionTest.php
@@ -105,6 +105,20 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Hodor\MessageQueue\Adapter\Amqp\Connection::disconnect
+     */
+    public function testConnectionIsClosedAfterExplicitlyDisconnecting()
+    {
+        $connection = new Connection($this->getRabbitCredentials());
+
+        $amqp_connection = $connection->getAmqpConnection();
+
+        $this->assertTrue($amqp_connection->isConnected());
+        $connection->disconnect();
+        $this->assertFalse($amqp_connection->isConnected());
+    }
+
+    /**
      * @return array
      */
     public function provideConnectionConfigMissingARequiredField()


### PR DESCRIPTION
In order to prevent a segmentation fault that sometimes
occurs in PHP 5.x, allowing an explict disconnect of
the connection before destructors come into play can
be necessary.

https://bugs.php.net/bug.php?id=72286
