### PR TITLE
Rename MQ\Message to MQ\IncomingMessage

### DIFF
--- a/src/Hodor/JobQueue/Superqueue.php
+++ b/src/Hodor/JobQueue/Superqueue.php
@@ -5,7 +5,7 @@ namespace Hodor\JobQueue;
 use DateTime;
 use Hodor\Database\AdapterFactory as DbAdapterFactory;
 use Hodor\Database\Exception\BufferedJobNotFoundException;
-use Hodor\MessageQueue\Message;
+use Hodor\MessageQueue\IncomingMessage;
 
 class Superqueue
 {
@@ -40,9 +40,9 @@ class Superqueue
     }
 
     /**
-     * @param Message $message
+     * @param IncomingMessage $message
      */
-    public function bufferJobFromBufferQueueToDatabase(Message $message)
+    public function bufferJobFromBufferQueueToDatabase(IncomingMessage $message)
     {
         $db = $this->getDatabase();
 
@@ -92,10 +92,10 @@ class Superqueue
     }
 
     /**
-     * @param Message $message
+     * @param IncomingMessage $message
      * @param DateTime $started_running_at
      */
-    public function markJobAsSuccessful(Message $message, DateTime $started_running_at)
+    public function markJobAsSuccessful(IncomingMessage $message, DateTime $started_running_at)
     {
         $this->markJobAsFinished($message, $started_running_at, function ($meta) {
             $this->getDatabase()->markJobAsSuccessful($meta);
@@ -103,10 +103,10 @@ class Superqueue
     }
 
     /**
-     * @param Message $message
+     * @param IncomingMessage $message
      * @param DateTime $started_running_at
      */
-    public function markJobAsFailed(Message $message, DateTime $started_running_at)
+    public function markJobAsFailed(IncomingMessage $message, DateTime $started_running_at)
     {
         $this->markJobAsFinished($message, $started_running_at, function ($meta) {
             $this->getDatabase()->markJobAsFailed($meta);
@@ -162,12 +162,12 @@ class Superqueue
     }
 
     /**
-     * @param Message $message
+     * @param IncomingMessage $message
      * @param DateTime $started_running_at
      * @param callable $mark_finished
      */
     private function markJobAsFinished(
-        Message $message,
+        IncomingMessage $message,
         DateTime $started_running_at,
         callable $mark_finished
     ) {

--- a/src/Hodor/MessageQueue/Adapter/Amqp/Consumer.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Consumer.php
@@ -3,7 +3,7 @@
 namespace Hodor\MessageQueue\Adapter\Amqp;
 
 use Hodor\MessageQueue\Adapter\ConsumerInterface;
-use Hodor\MessageQueue\Message as MqMessage;
+use Hodor\MessageQueue\IncomingMessage as MqMessage;
 use PhpAmqpLib\Channel\AMQPChannel;
 
 class Consumer implements ConsumerInterface

--- a/src/Hodor/MessageQueue/Adapter/ConfigInterface.php
+++ b/src/Hodor/MessageQueue/Adapter/ConfigInterface.php
@@ -2,7 +2,7 @@
 
 namespace Hodor\MessageQueue\Adapter;
 
-use Hodor\MessageQueue\Message;
+use Hodor\MessageQueue\IncomingMessage;
 
 interface ConfigInterface
 {

--- a/src/Hodor/MessageQueue/Adapter/ConsumerInterface.php
+++ b/src/Hodor/MessageQueue/Adapter/ConsumerInterface.php
@@ -2,7 +2,7 @@
 
 namespace Hodor\MessageQueue\Adapter;
 
-use Hodor\MessageQueue\Message;
+use Hodor\MessageQueue\IncomingMessage;
 
 interface ConsumerInterface
 {

--- a/src/Hodor/MessageQueue/IncomingMessage.php
+++ b/src/Hodor/MessageQueue/IncomingMessage.php
@@ -4,7 +4,7 @@ namespace Hodor\MessageQueue;
 
 use Hodor\MessageQueue\Adapter\MessageInterface;
 
-class Message
+class IncomingMessage
 {
     /**
      * @var MessageInterface

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConsumerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConsumerTest.php
@@ -5,7 +5,7 @@ namespace Hodor\MessageQueue\Adapter\Amqp;
 use Hodor\MessageQueue\Adapter\ConsumerInterface;
 use Hodor\MessageQueue\Adapter\ConsumerTest as BaseConsumerTest;
 use Hodor\MessageQueue\Adapter\Testing\Config;
-use Hodor\MessageQueue\Message;
+use Hodor\MessageQueue\IncomingMessage;
 use PHPUnit_Framework_TestCase;
 
 /**

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ProducerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ProducerTest.php
@@ -5,7 +5,7 @@ namespace Hodor\MessageQueue\Adapter\Amqp;
 use Hodor\MessageQueue\Adapter\ConsumerInterface;
 use Hodor\MessageQueue\Adapter\ProducerTest as BaseProducerTest;
 use Hodor\MessageQueue\Adapter\Testing\Config;
-use Hodor\MessageQueue\Message;
+use Hodor\MessageQueue\IncomingMessage;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -52,7 +52,7 @@ class ProducerTest extends BaseProducerTest
         $channel_factory = $this->generateChannelFactory($this->getTestConfig());
         $consumer = new Consumer('fast_jobs', $channel_factory);
 
-        $consumer->consumeMessage(function (Message $message) use (&$return) {
+        $consumer->consumeMessage(function (IncomingMessage $message) use (&$return) {
             $return = $message->getContent();
         });
 

--- a/tests/src/Hodor/MessageQueue/Adapter/ConsumerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/ConsumerTest.php
@@ -2,7 +2,7 @@
 
 namespace Hodor\MessageQueue\Adapter;
 
-use Hodor\MessageQueue\Message;
+use Hodor\MessageQueue\IncomingMessage;
 use PHPUnit_Framework_TestCase;
 
 abstract class ConsumerTest extends PHPUnit_Framework_TestCase
@@ -18,7 +18,7 @@ abstract class ConsumerTest extends PHPUnit_Framework_TestCase
 
         $this->produceMessage(json_encode($unique_message));
 
-        $this->getTestConsumer()->consumeMessage(function (Message $message) use ($unique_message) {
+        $this->getTestConsumer()->consumeMessage(function (IncomingMessage $message) use ($unique_message) {
             $this->assertEquals($unique_message, $message->getContent());
         });
     }

--- a/tests/src/Hodor/MessageQueue/Adapter/FactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/FactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace Hodor\MessageQueue\Adapter;
 
-use Hodor\MessageQueue\Message;
+use Hodor\MessageQueue\IncomingMessage;
 use PHPUnit_Framework_TestCase;
 
 abstract class FactoryTest extends PHPUnit_Framework_TestCase
@@ -21,7 +21,7 @@ abstract class FactoryTest extends PHPUnit_Framework_TestCase
 
         $factory->getProducer('fast_jobs')->produceMessage(json_encode($unique_message));
 
-        $factory->getConsumer('fast_jobs')->consumeMessage(function (Message $message) use ($unique_message) {
+        $factory->getConsumer('fast_jobs')->consumeMessage(function (IncomingMessage $message) use ($unique_message) {
             $this->assertEquals($unique_message, $message->getContent());
         });
     }

--- a/tests/src/Hodor/MessageQueue/Adapter/ProducerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/ProducerTest.php
@@ -2,7 +2,7 @@
 
 namespace Hodor\MessageQueue\Adapter;
 
-use Hodor\MessageQueue\Message;
+use Hodor\MessageQueue\IncomingMessage;
 use PHPUnit_Framework_TestCase;
 
 abstract class ProducerTest extends PHPUnit_Framework_TestCase

--- a/tests/src/Hodor/MessageQueue/IncomingMessageTest.php
+++ b/tests/src/Hodor/MessageQueue/IncomingMessageTest.php
@@ -5,9 +5,9 @@ namespace Hodor\MessageQueue;
 use PHPUnit_Framework_TestCase;
 
 /**
- * @coversDefaultClass Hodor\MessageQueue\Message
+ * @coversDefaultClass Hodor\MessageQueue\IncomingMessage
  */
-class MessageTest extends PHPUnit_Framework_TestCase
+class IncomingMessageTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @covers ::__construct
@@ -23,7 +23,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
             ->method('getContent')
             ->willReturn(json_encode($uniq_id));
 
-        $message = new Message($message_interface);
+        $message = new IncomingMessage($message_interface);
         $this->assertSame($uniq_id, $message->getContent());
     }
 
@@ -41,7 +41,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
             ->method('getContent')
             ->willReturn(json_encode($uniq_id));
 
-        $message = new Message($message_interface);
+        $message = new IncomingMessage($message_interface);
         $this->assertSame($uniq_id, $message->getContent());
         $this->assertSame($uniq_id, $message->getContent());
     }
@@ -57,7 +57,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('acknowledge');
 
-        $message = new Message($message_interface);
+        $message = new IncomingMessage($message_interface);
         $message->acknowledge();
     }
 
@@ -72,7 +72,7 @@ class MessageTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('acknowledge');
 
-        $message = new Message($message_interface);
+        $message = new IncomingMessage($message_interface);
         $message->acknowledge();
         $message->acknowledge();
     }


### PR DESCRIPTION
An OutgoingMessage is going to be introduced, but
first we want to make the existing name of the
Message class more specific to its purpose
