### PR TITLE
Acknowledge test messages after consuming them

### DIFF
--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ProducerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ProducerTest.php
@@ -54,7 +54,12 @@ class ProducerTest extends BaseProducerTest
 
         $consumer->consumeMessage(function (IncomingMessage $message) use (&$return) {
             $return = $message->getContent();
+            $message->acknowledge();
         });
+
+        // disconnect after consuming so the unused channel does not prefetch
+        // and hold a message unack'd while another channel is looking for it
+        $channel_factory->disconnectAll();
 
         return $return;
     }

--- a/tests/src/Hodor/MessageQueue/Adapter/ConsumerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/ConsumerTest.php
@@ -21,6 +21,7 @@ abstract class ConsumerTest extends PHPUnit_Framework_TestCase
 
         $this->getTestConsumer()->consumeMessage(function (IncomingMessage $message) use ($unique_message) {
             $this->assertEquals($unique_message, $message->getContent());
+            $message->acknowledge();
         });
     }
 

--- a/tests/src/Hodor/MessageQueue/Adapter/FactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/FactoryTest.php
@@ -24,6 +24,7 @@ abstract class FactoryTest extends PHPUnit_Framework_TestCase
 
         $factory->getConsumer('fast_jobs')->consumeMessage(function (IncomingMessage $message) use ($unique_message) {
             $this->assertEquals($unique_message, $message->getContent());
+            $message->acknowledge();
         });
     }
 


### PR DESCRIPTION
Rather than leaving messages sitting on a queue after a
test, let's acknowledge them so all queues are cleared
unless there is an error.

Ideally at some point in the future we will make the test
queues disappear, but for now keeping the test queues all
at zero messages will help debug when an issue arises.
