### PR TITLE
Enforce @covers PHPunit annotations

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,7 @@
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
+    forceCoversAnnotation="true"
 >
 
     <testsuites>


### PR DESCRIPTION
We want to make sure things are being explicitly
tested rather than having a test accidentally cover
another part of code
