### PR TITLE
Implement in-memory message queue testing adapters

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Testing/Consumer.php
+++ b/src/Hodor/MessageQueue/Adapter/Testing/Consumer.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Testing;
+
+use Hodor\MessageQueue\Adapter\ConsumerInterface;
+use Hodor\MessageQueue\IncomingMessage;
+
+class Consumer implements ConsumerInterface
+{
+    /**
+     * @var MessageBank
+     */
+    private $message_bank;
+
+    /**
+     * @param MessageBank $message_bank
+     */
+    public function __construct(MessageBank $message_bank)
+    {
+        $this->message_bank = $message_bank;
+    }
+
+    /**
+     * @param callable $callback
+     */
+    public function consumeMessage(callable $callback)
+    {
+        $message_adapter = $this->message_bank->consumeMessage();
+        $incoming_message = new IncomingMessage($message_adapter);
+
+        $callback($incoming_message);
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxMessagesPerConsume()
+    {
+        return $this->message_bank->getMaxMessagesPerConsume();
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxTimePerConsume()
+    {
+        return $this->message_bank->getMaxTimePerConsume();
+    }
+}

--- a/src/Hodor/MessageQueue/Adapter/Testing/Factory.php
+++ b/src/Hodor/MessageQueue/Adapter/Testing/Factory.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Testing;
+
+use Hodor\MessageQueue\Adapter\ConfigInterface;
+use Hodor\MessageQueue\Adapter\ConsumerInterface;
+use Hodor\MessageQueue\Adapter\FactoryInterface;
+use Hodor\MessageQueue\Adapter\ProducerInterface;
+
+class Factory implements FactoryInterface
+{
+    /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
+     * @var Consumer[]
+     */
+    private $consumers = [];
+
+    /**
+     * @var Producer[]
+     */
+    private $producers = [];
+
+    /**
+     * @var MessageBank[]
+     */
+    private $message_banks = [];
+
+    /**
+     * @param ConfigInterface $config
+     */
+    public function __construct(ConfigInterface $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @param string $queue_key
+     * @return ConsumerInterface
+     */
+    public function getConsumer($queue_key)
+    {
+        if (array_key_exists($queue_key, $this->consumers)) {
+            return $this->consumers[$queue_key];
+        }
+
+        $this->consumers[$queue_key] = new Consumer($this->getMessageBank($queue_key));
+
+        return $this->consumers[$queue_key];
+    }
+
+    /**
+     * @param string $queue_key
+     * @return ProducerInterface
+     */
+    public function getProducer($queue_key)
+    {
+        if (array_key_exists($queue_key, $this->producers)) {
+            return $this->producers[$queue_key];
+        }
+
+        $this->producers[$queue_key] = new Producer($this->getMessageBank($queue_key));
+
+        return $this->producers[$queue_key];
+    }
+
+    /**
+     * @param string $queue_key
+     * @return MessageBank
+     */
+    private function getMessageBank($queue_key)
+    {
+        if (!empty($this->message_banks[$queue_key])) {
+            return $this->message_banks[$queue_key];
+        }
+
+        $this->message_banks[$queue_key] = new MessageBank($this->config->getQueueConfig($queue_key));
+
+        return $this->message_banks[$queue_key];
+    }
+}

--- a/src/Hodor/MessageQueue/Adapter/Testing/Message.php
+++ b/src/Hodor/MessageQueue/Adapter/Testing/Message.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Testing;
+
+use Hodor\MessageQueue\Adapter\MessageInterface;
+
+class Message implements MessageInterface
+{
+    /**
+     * @var
+     */
+    private $body;
+
+    /**
+     * @var MessageBank $message_bank
+     */
+    private $message_bank;
+
+    /**
+     * @var string
+     */
+    private $message_id;
+
+    /**
+     * @param string $body
+     * @param MessageBank $message_bank
+     * @param string $message_id
+     */
+    public function __construct($body, MessageBank $message_bank, $message_id)
+    {
+        $this->body = $body;
+        $this->message_bank = $message_bank;
+        $this->message_id = $message_id;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getContent()
+    {
+        return $this->body;
+    }
+
+    public function acknowledge()
+    {
+        return $this->message_bank->acknowledgeMessage($this->message_id);
+    }
+}

--- a/src/Hodor/MessageQueue/Adapter/Testing/MessageBank.php
+++ b/src/Hodor/MessageQueue/Adapter/Testing/MessageBank.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Testing;
+
+use Exception;
+
+class MessageBank
+{
+    /**
+     * @var array
+     */
+    private $messages = [];
+
+    /**
+     * @param array $queue_config
+     */
+    public function __construct(array $queue_config = [])
+    {
+        $this->queue_config = array_merge(
+            [
+                'max_messages_per_consume' => 1,
+                'max_time_per_consume'     => 600,
+            ],
+            $queue_config
+        );
+    }
+
+    /**
+     * @param string $message_id
+     * @throws Exception
+     */
+    public function acknowledgeMessage($message_id)
+    {
+        if (!array_key_exists($message_id, $this->messages)) {
+            throw new Exception("Message with ID '{$message_id}' not found when acking message.");
+        }
+
+        $this->messages[$message_id]['is_acked'] = true;
+    }
+
+    /**
+     * @param string $content
+     */
+    public function produceMessage($content)
+    {
+        $this->messages[uniqid()] = [
+            'content'     => $content,
+            'is_acked'    => false,
+            'is_received' => false,
+        ];
+    }
+
+    /**
+     * @return Message
+     * @throws Exception
+     */
+    public function consumeMessage()
+    {
+        foreach ($this->messages as $message_id => &$message) {
+            if (!$message['is_received']) {
+                $message['is_received'] = true;
+                return new Message($message['content'], $this, $message_id);
+            }
+        }
+
+        throw new Exception("There are no messages to consume.");
+    }
+
+    public function emulateReconnect()
+    {
+        $original_messages = $this->messages;
+        $this->messages = [];
+        foreach ($original_messages as $message) {
+            if (!$message['is_acked']) {
+                $this->produceMessage($message['content']);
+            }
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxMessagesPerConsume()
+    {
+        return $this->queue_config['max_messages_per_consume'];
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxTimePerConsume()
+    {
+        return $this->queue_config['max_time_per_consume'];
+    }
+}

--- a/src/Hodor/MessageQueue/Adapter/Testing/Producer.php
+++ b/src/Hodor/MessageQueue/Adapter/Testing/Producer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Testing;
+
+use Hodor\MessageQueue\Adapter\ProducerInterface;
+use Hodor\MessageQueue\OutgoingMessage;
+
+class Producer implements ProducerInterface
+{
+    /**
+     * @var MessageBank
+     */
+    private $message_bank;
+
+    /**
+     * @param MessageBank $message_bank
+     */
+    public function __construct(MessageBank $message_bank)
+    {
+        $this->message_bank = $message_bank;
+    }
+
+    /**
+     * @param OutgoingMessage $message
+     */
+    public function produceMessage(OutgoingMessage $message)
+    {
+        $this->message_bank->produceMessage($message->getEncodedContent());
+    }
+
+    /**
+     * @param string[] $messages
+     */
+    public function produceMessageBatch(array $messages)
+    {
+        foreach ($messages as $message) {
+            $this->message_bank->produceMessage($message->getEncodedContent());
+        }
+    }
+}

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/ConsumerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/ConsumerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Testing;
+
+use Hodor\MessageQueue\Adapter\Amqp\ConfigProvider;
+use Hodor\MessageQueue\Adapter\ConsumerInterface;
+use Hodor\MessageQueue\Adapter\ConsumerTest as BaseConsumerTest;
+use Hodor\MessageQueue\OutgoingMessage;
+
+/**
+ * @coversDefaultClass Hodor\MessageQueue\Adapter\Testing\Consumer
+ */
+class ConsumerTest extends BaseConsumerTest
+{
+    /**
+     * @var MessageBank[]
+     */
+    private $message_banks = [];
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @param array $config_overrides
+     * @return ConsumerInterface
+     */
+    protected function getTestConsumer(array $config_overrides = [])
+    {
+        $message_bank = $this->getMessageBank('fast_jobs', $this->getTestConfig($config_overrides));
+        $test_consumer = new Consumer($message_bank);
+
+        return $test_consumer;
+    }
+
+    /**
+     * @param OutgoingMessage $message
+     */
+    protected function produceMessage(OutgoingMessage $message)
+    {
+        $message_bank = $this->getMessageBank('fast_jobs', $this->getTestConfig());
+        $producer = new Producer($message_bank);
+
+        $producer->produceMessage($message);
+    }
+
+    /**
+     * @param string $queue_key
+     * @param Config $config
+     * @return MessageBank
+     */
+    private function getMessageBank($queue_key, Config $config)
+    {
+        if (!empty($this->message_banks[$queue_key])) {
+            return $this->message_banks[$queue_key];
+        }
+
+        $this->message_banks[$queue_key] = new MessageBank($config->getQueueConfig($queue_key));
+
+        return $this->message_banks[$queue_key];
+    }
+
+    /**
+     * @param array $config_overrides
+     * @return Config
+     */
+    private function getTestConfig(array $config_overrides = [])
+    {
+        if ($this->config) {
+            return $this->config;
+        }
+
+        $config_provider = new ConfigProvider($this);
+        $test_queues = $this->getTestQueues($config_provider);
+        $this->config = $config_provider->getConfigAdapter($test_queues, $config_overrides);
+
+        return $this->config;
+    }
+
+    /**
+     * @param ConfigProvider $config_provider
+     * @return array
+     */
+    private function getTestQueues(ConfigProvider $config_provider)
+    {
+        return [
+            'fast_jobs' => $config_provider->getQueueConfig(),
+        ];
+    }
+}

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/FactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/FactoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Testing;
+
+use Hodor\MessageQueue\Adapter\Amqp\ConfigProvider;
+use Hodor\MessageQueue\Adapter\FactoryTest as BaseFactoryTest;
+
+/**
+ * @coversDefaultClass Hodor\MessageQueue\Adapter\Testing\Factory
+ */
+class FactoryTest extends BaseFactoryTest
+{
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @param array $config_overrides
+     * @return Factory
+     */
+    protected function getTestFactory(array $config_overrides = [])
+    {
+        return new Factory($this->getTestConfig($config_overrides));
+    }
+
+    /**
+     * @param array $config_overrides
+     * @return Config
+     */
+    private function getTestConfig(array $config_overrides = [])
+    {
+        if ($this->config) {
+            return $this->config;
+        }
+
+        $config_provider = new ConfigProvider($this);
+        $test_queues = $this->getTestQueues($config_provider);
+        $this->config = $config_provider->getConfigAdapter($test_queues, $config_overrides);
+
+        return $this->config;
+    }
+
+    /**
+     * @param ConfigProvider $config_provider
+     * @return array
+     */
+    private function getTestQueues(ConfigProvider $config_provider)
+    {
+        return [
+            'fast_jobs' => $config_provider->getQueueConfig(),
+        ];
+    }
+}

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/MessageBankTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/MessageBankTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Testing;
+
+use Exception;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @coversDefaultClass Hodor\MessageQueue\Adapter\Testing\MessageBank
+ */
+class MessageBankTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::getMaxMessagesPerConsume
+     */
+    public function testMaxMessagesPerConsumePassedToConstructorIsTheSameRetrieved()
+    {
+        $max_messages = rand(1, 100);
+
+        $message_bank = new MessageBank([
+            'max_messages_per_consume' => $max_messages,
+        ]);
+
+        $this->assertEquals($max_messages, $message_bank->getMaxMessagesPerConsume());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getMaxMessagesPerConsume
+     */
+    public function testMaxMessagesPerConsumePassedToConstructorCanBeDefaulted()
+    {
+        $message_bank = new MessageBank();
+
+        $this->assertEquals(1, $message_bank->getMaxMessagesPerConsume());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getMaxTimePerConsume
+     */
+    public function testMaxTimePerConsumePassedToConstructorIsTheSameRetrieved()
+    {
+        $max_time = rand(1, 100);
+
+        $message_bank = new MessageBank([
+            'max_time_per_consume' => $max_time,
+        ]);
+
+        $this->assertEquals($max_time, $message_bank->getMaxTimePerConsume());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getMaxTimePerConsume
+     */
+    public function testMaxTimePerConsumePassedToConstructorCanBeDefaulted()
+    {
+        $message_bank = new MessageBank();
+
+        $this->assertEquals(600, $message_bank->getMaxTimePerConsume());
+    }
+
+    /**
+     * @covers ::consumeMessage
+     * @expectedException Exception
+     */
+    public function testConsumingWhileNoMessagesAreQueuedThrowsAnException()
+    {
+        $message_bank = new MessageBank();
+
+        $message_bank->consumeMessage();
+    }
+
+    /**
+     * @covers ::consumeMessage
+     * @covers ::produceMessage
+     */
+    public function testProducedMessageCanBeConsumed()
+    {
+        $message_bank = new MessageBank();
+
+        $message = uniqid();
+
+        $message_bank->produceMessage($message);
+        $this->assertSame($message, $message_bank->consumeMessage()->getContent());
+    }
+
+    /**
+     * @covers ::consumeMessage
+     * @covers ::produceMessage
+     */
+    public function testMultipleProducedMessagesCanBeConsumed()
+    {
+        $message_bank = new MessageBank();
+
+        $messages = [
+            'a-' . uniqid(),
+            'b-' . uniqid(),
+        ];
+        foreach ($messages as $message) {
+            $message_bank->produceMessage($message);
+        }
+
+        foreach ($messages as $message) {
+            $this->assertSame($message, $message_bank->consumeMessage()->getContent());
+        }
+    }
+
+    /**
+     * @covers ::consumeMessage
+     * @covers ::produceMessage
+     * @expectedException Exception
+     */
+    public function testConsumingWhileNoUnreceivedMessagesAreQueuedThrowsAnException()
+    {
+        $message_bank = new MessageBank();
+
+        $message_bank->produceMessage('does-not-matter');
+        $message_bank->consumeMessage();
+        $message_bank->consumeMessage();
+    }
+
+    /**
+     * @covers ::acknowledgeMessage
+     * @expectedException Exception
+     */
+    public function testAnUnknownMessageCannotBeAcknowledged()
+    {
+        $message_bank = new MessageBank();
+
+        $message_bank->acknowledgeMessage('unknown');
+    }
+
+    /**
+     * @covers ::consumeMessage
+     * @covers ::produceMessage
+     * @covers ::acknowledgeMessage
+     * @covers ::emulateReconnect
+     */
+    public function testOnlyAckedMessagesComeBackOnReconnect()
+    {
+        $message_bank = new MessageBank();
+
+        $acked_message = 'a-' . uniqid();
+        $unacked_message = 'b-' . uniqid();
+
+        $message_bank->produceMessage($acked_message);
+        $message_bank->produceMessage($unacked_message);
+
+        $consumed_ack_message = $message_bank->consumeMessage();
+        $this->assertSame($acked_message, $consumed_ack_message->getContent());
+        $consumed_ack_message->acknowledge();
+
+        $this->assertSame($unacked_message, $message_bank->consumeMessage()->getContent());
+
+        $message_bank->emulateReconnect();
+
+        $this->assertSame($unacked_message, $message_bank->consumeMessage()->getContent());
+    }
+}

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/MessageTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/MessageTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Testing;
+
+use Hodor\MessageQueue\Adapter\MessageTest as BaseMessageTest;
+
+/**
+ * @coversDefaultClass Hodor\MessageQueue\Adapter\Testing\Message
+ */
+class MessageTest extends BaseMessageTest
+{
+    /**
+     * @param string $body
+     * @return Message
+     */
+    protected function getBasicMessage($body)
+    {
+        return new Message($body, new MessageBank(), '');
+    }
+
+    /**
+     * @return Message
+     */
+    protected function getAcknowledgeableMessage()
+    {
+        $message_id = 'hey_there!';
+
+        $message_bank = $this->getMockBuilder('\Hodor\MessageQueue\Adapter\Testing\MessageBank')
+            ->disableOriginalConstructor()
+            ->setMethods(['acknowledgeMessage'])
+            ->getMock();
+        $message_bank->expects($this->once())
+            ->method('acknowledgeMessage')
+            ->with($message_id);
+
+        return new Message('', $message_bank, $message_id);
+    }
+}

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/ProducerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/ProducerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Testing;
+
+use Hodor\MessageQueue\Adapter\Amqp\ConfigProvider;
+use Hodor\MessageQueue\Adapter\ProducerInterface;
+use Hodor\MessageQueue\Adapter\ProducerTest as BaseProducerTest;
+use Hodor\MessageQueue\IncomingMessage;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @coversDefaultClass Hodor\MessageQueue\Adapter\Testing\Producer
+ */
+class ProducerTest extends BaseProducerTest
+{
+    /**
+     * @var MessageBank[]
+     */
+    private $message_banks = [];
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+
+    /**
+     * @param array $config_overrides
+     * @return ProducerInterface
+     */
+    protected function getTestProducer(array $config_overrides = [])
+    {
+        $message_bank = $this->getMessageBank('fast_jobs', $this->getTestConfig($config_overrides));
+        $test_producer = new Producer($message_bank);
+
+        return $test_producer;
+    }
+
+    /**
+     * @return string
+     */
+    protected function consumeMessage()
+    {
+        $message_bank = $this->getMessageBank('fast_jobs', $this->getTestConfig());
+        $consumer = new Consumer($message_bank);
+
+        $consumer->consumeMessage(function (IncomingMessage $message) use (&$return) {
+            $return = $message->getContent();
+            $message->acknowledge();
+        });
+
+        return $return;
+    }
+
+    /**
+     * @param string $queue_key
+     * @param Config $config
+     * @return MessageBank
+     */
+    private function getMessageBank($queue_key, Config $config)
+    {
+        if (!empty($this->message_banks[$queue_key])) {
+            return $this->message_banks[$queue_key];
+        }
+
+        $this->message_banks[$queue_key] = new MessageBank($config->getQueueConfig($queue_key));
+
+        return $this->message_banks[$queue_key];
+    }
+
+    /**
+     * @param array $config_overrides
+     * @return Config
+     */
+    private function getTestConfig(array $config_overrides = [])
+    {
+        if ($this->config) {
+            return $this->config;
+        }
+
+        $config_provider = new ConfigProvider($this);
+        $test_queues = $this->getTestQueues($config_provider);
+        $this->config = $config_provider->getConfigAdapter($test_queues, $config_overrides);
+
+        return $this->config;
+    }
+
+    /**
+     * @param ConfigProvider $config_provider
+     * @return array
+     */
+    private function getTestQueues(ConfigProvider $config_provider)
+    {
+        return [
+            'fast_jobs' => $config_provider->getQueueConfig(),
+        ];
+    }
+}


### PR DESCRIPTION
When we go to test the other components of the job queue,
we'd rather not build mocks but we also do not want to be
connecting to RabbitMQ for every test.  The in-memory MQ
adapters will allow us to test functionality that depends
on the MQ adapters using an in-memory solution that functions
like RabbitMQ does.
