### PR TITLE
Generate adapter factory just in time in Testing\Config

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Testing/Config.php
+++ b/src/Hodor/MessageQueue/Adapter/Testing/Config.php
@@ -19,11 +19,16 @@ class Config implements ConfigInterface
     private $queues = [];
 
     /**
-     * @param FactoryInterface $adapter_factory
+     * @var callable
      */
-    public function __construct(FactoryInterface $adapter_factory)
+    private $adapter_factory_generator;
+
+    /**
+     * @param callable $adapter_factory_generator
+     */
+    public function __construct(callable $adapter_factory_generator)
     {
-        $this->adapter_factory = $adapter_factory;
+        $this->adapter_factory_generator = $adapter_factory_generator;
     }
 
     /**
@@ -31,6 +36,13 @@ class Config implements ConfigInterface
      */
     public function getAdapterFactory()
     {
+        if ($this->adapter_factory) {
+            return $this->adapter_factory;
+        }
+
+        $adapter_factory_generator = $this->adapter_factory_generator;
+        $this->adapter_factory = $adapter_factory_generator($this);
+
         return $this->adapter_factory;
     }
 

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConfigProvider.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConfigProvider.php
@@ -27,7 +27,9 @@ class ConfigProvider
      */
     public function getConfigAdapter(array $queues, array $config_overrides = [])
     {
-        $config = new Config($this->test_case->getMock('Hodor\MessageQueue\Adapter\FactoryInterface'));
+        $config = new Config(function () {
+            return $this->test_case->getMock('Hodor\MessageQueue\Adapter\FactoryInterface');
+        });
         foreach ($queues as $queue_key => $queue_config) {
             $config->addQueueConfig($queue_key, array_merge($queue_config, $config_overrides));
         }

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/ConfigTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/ConfigTest.php
@@ -14,10 +14,39 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * @covers ::__construct
      * @covers ::getAdapterFactory
      */
+    public function testAdapterFactoryReturnedIsSameReturnedByFactoryGenerator()
+    {
+        $adapter_factory = $this->getAdapterFactoryMock();
+        $config = new Config(function () use ($adapter_factory) {
+            return $adapter_factory;
+        });
+
+        $this->assertSame($adapter_factory, $config->getAdapterFactory());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getAdapterFactory
+     */
+    public function testAdapterFactoryIsLazyLoaded()
+    {
+        $config = new Config(function () {
+            return $this->getAdapterFactoryMock();
+        });
+
+        $this->assertSame($config->getAdapterFactory(), $config->getAdapterFactory());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getAdapterFactory
+     */
     public function testAdapterFactoryReturnedIsSameProvidedToConstructor()
     {
         $adapter_factory = $this->getAdapterFactoryMock();
-        $config = new Config($adapter_factory);
+        $config = new Config(function () use ($adapter_factory) {
+            return $adapter_factory;
+        });
 
         $this->assertSame($adapter_factory, $config->getAdapterFactory());
     }
@@ -30,7 +59,9 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      */
     public function testRetrievingUndefinedQueueThrowsAnException($queue_key)
     {
-        $config = new Config($this->getAdapterFactoryMock());
+        $config = new Config(function () {
+            return $this->getAdapterFactoryMock();
+        });
 
         $config->getQueueConfig($queue_key);
     }
@@ -44,7 +75,9 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      */
     public function testAddedQueueConfigCanBeRetrieved($queue_key, array $queue_config)
     {
-        $config = new Config($this->getAdapterFactoryMock());
+        $config = new Config(function () {
+            return $this->getAdapterFactoryMock();
+        });
 
         $config->addQueueConfig($queue_key, $queue_config);
         $this->assertEquals($queue_config, $config->getQueueConfig($queue_key));


### PR DESCRIPTION
The Config constructor requires an AdapterFactory and the
AdapterFactory constructor requires a Config. Up until now
the two testing classes have not yet needed to be used with
each other. We may want to stop supplying the adapter
factory through the config object, but for now let's use a
callable to generate the adapter factory so the Config
constructor does not directly require an AdapterFactory.
