### PR TITLE
Replace documentation with new method

### DIFF
--- a/src/Hodor/Command/DatabaseMigrateCommand.php
+++ b/src/Hodor/Command/DatabaseMigrateCommand.php
@@ -48,10 +48,7 @@ class DatabaseMigrateCommand extends Command
             return;
         }
 
-        /**
-         * @var $phpmig_adapter PgsqlPhpmigAdapter
-         */
-        $phpmig_adapter = $phpmig_container['phpmig.adapter'];
+        $phpmig_adapter = $phpmig_container->getPhpmigAdapter();
         if (!$phpmig_adapter->hasSchema()) {
             $phpmig_adapter->createSchema();
         }

--- a/src/Hodor/Database/Phpmig/Container.php
+++ b/src/Hodor/Database/Phpmig/Container.php
@@ -72,6 +72,14 @@ class Container extends Pimple
     }
 
     /**
+     * @return PgsqlPhpmigAdapter
+     */
+    public function getPhpmigAdapter()
+    {
+        return $this['phpmig.adapter'];
+    }
+
+    /**
      * @param $config_file
      * @throws Exception
      */


### PR DESCRIPTION
Rather than having PHPdoc at call-time, define
the dependency in the Container's method and
document the type in the declaration
