### PR TITLE
Allow JobQueue\Config to return a testing adapter factory

### DIFF
--- a/src/Hodor/JobQueue/Config.php
+++ b/src/Hodor/JobQueue/Config.php
@@ -3,11 +3,18 @@
 namespace Hodor\JobQueue;
 
 use Exception;
-use Hodor\MessageQueue\Adapter\Amqp\Factory;
+use Hodor\MessageQueue\Adapter\Amqp\Factory as AmqpFactory;
 use Hodor\MessageQueue\Adapter\ConfigInterface;
+use Hodor\MessageQueue\Adapter\FactoryInterface;
+use Hodor\MessageQueue\Adapter\Testing\Factory as TestingFactory;
 
 class Config implements ConfigInterface
 {
+    /**
+     * @var FactoryInterface
+     */
+    private $adapter_factory;
+
     /**
      * @var string
      */
@@ -178,11 +185,17 @@ class Config implements ConfigInterface
     }
 
     /**
-     * @return Factory
+     * @return FactoryInterface
      */
     public function getAdapterFactory()
     {
-        return new Factory($this);
+        if ($this->adapter_factory) {
+            return $this->adapter_factory;
+        }
+
+        $this->adapter_factory = $this->generateAdapterFactory();
+
+        return $this->adapter_factory;
     }
 
     /**
@@ -234,6 +247,18 @@ class Config implements ConfigInterface
         $config['process_count'] = $config[$queue_type_keys['process_count_key']];
 
         return $config;
+    }
+
+    /**
+     * @return FactoryInterface
+     */
+    private function generateAdapterFactory()
+    {
+        if ('testing' === $this->getOption('adapter_factory')) {
+            return new TestingFactory($this);
+        }
+
+        return new AmqpFactory($this);
     }
 
     /**

--- a/tests/src/Hodor/JobQueue/ConfigTest.php
+++ b/tests/src/Hodor/JobQueue/ConfigTest.php
@@ -86,6 +86,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers ::generateAdapterFactory
      * @covers ::getAdapterFactory
      */
     public function testAdapterFactoryCanBeRetrieved()
@@ -93,6 +94,32 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(
             'Hodor\MessageQueue\Adapter\Amqp\Factory',
             (new Config(__FILE__, []))->getAdapterFactory()
+        );
+    }
+
+    /**
+     * @covers ::generateAdapterFactory
+     * @covers ::getAdapterFactory
+     */
+    public function testAdapterFactoryIsReused()
+    {
+        $config = new Config(__FILE__, []);
+
+        $this->assertSame(
+            $config->getAdapterFactory(),
+            $config->getAdapterFactory()
+        );
+    }
+
+    /**
+     * @covers ::generateAdapterFactory
+     * @covers ::getAdapterFactory
+     */
+    public function testTestingAdapterFactoryCanBeRetrieved()
+    {
+        $this->assertInstanceOf(
+            'Hodor\MessageQueue\Adapter\Testing\Factory',
+            (new Config(__FILE__, ['adapter_factory' => 'testing']))->getAdapterFactory()
         );
     }
 


### PR DESCRIPTION
For tests that depend on the Config object and
publishing/consuming messages, being able to switch to the
testing adapter will make things somewhat cleaner.
