### PR TITLE
Move Superqueue DbAdapter generation to QueueManager

### DIFF
--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -2,6 +2,8 @@
 
 namespace Hodor\JobQueue;
 
+use Hodor\Database\AdapterFactory as DbAdapterFactory;
+use Hodor\Database\AdapterInterface as DbAdapterInterface;
 use Hodor\JobQueue\JobOptions\Validator as JobOptionsValidator;
 use Hodor\MessageQueue\Queue as MessageQueue;
 use Hodor\MessageQueue\QueueFactory as MqFactory;
@@ -34,6 +36,11 @@ class QueueManager
     private $job_options_validator;
 
     /**
+     * @var DbAdapterInterface
+     */
+    private $database;
+
+    /**
      * @param Config $config
      */
     public function __construct(Config $config)
@@ -50,8 +57,7 @@ class QueueManager
             return $this->superqueue;
         }
 
-        $queue_config = $this->config->getSuperqueueConfig();
-        $this->superqueue = new Superqueue($queue_config, $this);
+        $this->superqueue = new Superqueue($this);
 
         return $this->superqueue;
     }
@@ -153,6 +159,23 @@ class QueueManager
     public function discardBatch()
     {
         $this->getMessageQueueFactory()->discardBatch();
+    }
+
+    /**
+     * @return DbAdapterInterface
+     */
+    public function getDatabase()
+    {
+        if ($this->database) {
+            return $this->database;
+        }
+
+        $config = $this->config->getSuperqueueConfig();
+        $db_adapter_factory = new DbAdapterFactory($config['database']);
+
+        $this->database = $db_adapter_factory->getAdapter($config['database']['type']);
+
+        return $this->database;
     }
 
     /**

--- a/src/Hodor/JobQueue/Superqueue.php
+++ b/src/Hodor/JobQueue/Superqueue.php
@@ -3,18 +3,12 @@
 namespace Hodor\JobQueue;
 
 use DateTime;
-use Hodor\Database\AdapterFactory as DbAdapterFactory;
 use Hodor\Database\AdapterInterface as DbAdapterInterface;
 use Hodor\Database\Exception\BufferedJobNotFoundException;
 use Hodor\MessageQueue\IncomingMessage;
 
 class Superqueue
 {
-    /**
-     * @var array
-     */
-    private $config;
-
     /**
      * @var QueueManager
      */
@@ -31,12 +25,10 @@ class Superqueue
     private $jobs_queued = 0;
 
     /**
-     * @param array $config
      * @param QueueManager $queue_manager
      */
-    public function __construct(array $config, QueueManager $queue_manager)
+    public function __construct(QueueManager $queue_manager)
     {
-        $this->config = $config;
         $this->queue_manager = $queue_manager;
     }
 
@@ -200,9 +192,7 @@ class Superqueue
             return $this->database;
         }
 
-        $db_adapter_factory = new DbAdapterFactory($this->config['database']);
-
-        $this->database = $db_adapter_factory->getAdapter($this->config['database']['type']);
+        $this->database = $this->queue_manager->getDatabase();
 
         return $this->database;
     }


### PR DESCRIPTION
We need the Database adapter to be configurable so we
can test things with a Testing DB adapter similar to
how we can switch between the Amqp and Testing MQ adapters
