### PR TITLE
Rollback DB migrations before each PgsqlAdapter test

### DIFF
--- a/src/Hodor/Database/Phpmig/CommandWrapper.php
+++ b/src/Hodor/Database/Phpmig/CommandWrapper.php
@@ -48,4 +48,14 @@ class CommandWrapper
         }
         $phpmig->up();
     }
+
+    public function rollbackMigrations()
+    {
+        $phpmig = new PhpmigApplication($this->container, $this->output);
+        $phpmig_adapter = $this->container->getPhpmigAdapter();
+        if (!$phpmig_adapter->hasSchema()) {
+            $phpmig_adapter->createSchema();
+        }
+        $phpmig->down(0);
+    }
 }

--- a/tests/src/Hodor/Database/PgsqlAdapterTest.php
+++ b/tests/src/Hodor/Database/PgsqlAdapterTest.php
@@ -29,6 +29,7 @@ class PgsqlAdapterTest extends PHPUnit_Framework_TestCase
         $phpmig_container['hodor.database'] = $this->pgsql_adapter;
 
         $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
+        $command_wrapper->rollbackMigrations();
         $command_wrapper->runMigrations();
 
         while (iterator_to_array($this->pgsql_adapter->getJobsToRunGenerator())) {


### PR DESCRIPTION
Rolling back the migrations before performing the migration
will make sure we are dealing with a clean database for
each test
