### PR TITLE
Reduce concurrent connections in PgsqlAdapterTest

### DIFF
--- a/tests/src/Hodor/Database/PgsqlAdapterTest.php
+++ b/tests/src/Hodor/Database/PgsqlAdapterTest.php
@@ -37,6 +37,14 @@ class PgsqlAdapterTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    public function tearDown()
+    {
+        $this->pgsql_adapter = null;
+        // without forcing garbage collection, the DB connections
+        // are not guaranteed to be disconnected; force GC
+        gc_collect_cycles();
+    }
+
     /**
      * @covers ::__construct
      * @covers ::bufferJob


### PR DESCRIPTION
PDO connections are only terminated when they are garbage
collected. Since PHP is not requesting garbage collection
after each test, the number of concurrent database
connections kept growing and transactions were sometimes
conflicting with each other.
