### PR TITLE
Remove obsolete queueJobs() cleanup loop in PgsqlAdapterTest

### DIFF
--- a/tests/src/Hodor/Database/PgsqlAdapterTest.php
+++ b/tests/src/Hodor/Database/PgsqlAdapterTest.php
@@ -31,10 +31,6 @@ class PgsqlAdapterTest extends PHPUnit_Framework_TestCase
         $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
         $command_wrapper->rollbackMigrations();
         $command_wrapper->runMigrations();
-
-        while (iterator_to_array($this->pgsql_adapter->getJobsToRunGenerator())) {
-            $this->queueJobs(null, []);
-        }
     }
 
     public function tearDown()


### PR DESCRIPTION
Since migrations are rolled back and re-migrated for every
test, queueing all unqueued jobs is unnecessary
