### PR TITLE
Remove unused rollbackTransaction() method

### DIFF
--- a/src/Hodor/Database/AdapterInterface.php
+++ b/src/Hodor/Database/AdapterInterface.php
@@ -40,7 +40,6 @@ interface AdapterInterface
 
     public function beginTransaction();
     public function commitTransaction();
-    public function rollbackTransaction();
 
     /**
      * @param $category

--- a/src/Hodor/Database/PgsqlAdapter.php
+++ b/src/Hodor/Database/PgsqlAdapter.php
@@ -164,11 +164,6 @@ SQL;
         $this->queryMultiple('COMMIT');
     }
 
-    public function rollbackTransaction()
-    {
-        $this->queryMultiple('ROLLBACK');
-    }
-
     /**
      * @param $category
      * @param $name

--- a/tests/src/Hodor/Database/PgsqlAdapterTest.php
+++ b/tests/src/Hodor/Database/PgsqlAdapterTest.php
@@ -132,28 +132,6 @@ class PgsqlAdapterTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers ::beginTransaction
-     * @covers ::rollbackTransaction
-     * @covers ::queryMultiple
-     */
-    public function testTransactionCanBeRolledback()
-    {
-        $this->pgsql_adapter->beginTransaction();
-
-        $uniqid = uniqid();
-        $this->bufferJobs($uniqid, [
-            ['name' => 1, 'mutex_id' => 'a'],
-            ['name' => 2, 'mutex_id' => 'a'],
-        ]);
-
-        $this->assertJobsToRun($uniqid, ['1']);
-
-        $this->pgsql_adapter->rollbackTransaction();
-
-        $this->assertJobsToRun($uniqid, []);
-    }
-
-    /**
-     * @covers ::beginTransaction
      * @covers ::commitTransaction
      * @covers ::queryMultiple
      */


### PR DESCRIPTION
The method was only added for theoretical reasons
and right now it is getting in the way
