### PR TITLE
Fix misplaced transaction

### DIFF
--- a/src/Hodor/Database/PgsqlAdapter.php
+++ b/src/Hodor/Database/PgsqlAdapter.php
@@ -52,7 +52,9 @@ class PgsqlAdapter implements AdapterInterface
             $row['mutex_id'] = $job['options']['mutex_id'];
         }
 
+        $this->beginTransaction();
         $this->getDriver()->insert('buffered_jobs', $row);
+        $this->commitTransaction();
     }
 
     /**
@@ -100,7 +102,6 @@ SQL;
      */
     public function markJobAsQueued(array $job)
     {
-        $this->beginTransaction();
         $this->getDriver()->delete(
             'buffered_jobs',
             'buffered_job_id = :buffered_job_id',
@@ -125,7 +126,6 @@ SQL;
                 'mutex_id'         => $job['mutex_id'],
             ]
         );
-        $this->commitTransaction();
 
         return ['buffered_job_id' => $job['buffered_job_id']];
     }


### PR DESCRIPTION
PR #180 moved 2 of the 3 transaction begin/commits from
the Superqueue to PgsqlAdapter, but the bufferJob()
transaction was eliminated and the markJobAsQueued()
transaction was duplicated.  This PR removes the duplicate
transaction from markJobAsQueued() and adds a transaction
to bufferJob().
