### PR TITLE
Abstract PgsqlAdapter into smaller adapters

### DIFF
--- a/src/Hodor/Database/Adapter/Postgres/BufferWorker.php
+++ b/src/Hodor/Database/Adapter/Postgres/BufferWorker.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Hodor\Database\Adapter\Postgres;
+
+use Hodor\Database\Adapter\BufferWorkerInterface;
+use Lstr\YoPdo\YoPdo;
+
+class BufferWorker implements BufferWorkerInterface
+{
+    /**
+     * @var YoPdo
+     */
+    private $yo_pdo;
+
+    /**
+     * @param YoPdo $yo_pdo
+     */
+    public function __construct(YoPdo $yo_pdo)
+    {
+        $this->yo_pdo = $yo_pdo;
+    }
+
+    /**
+     * @param string $queue_name
+     * @param array $job
+     */
+    public function bufferJob($queue_name, array $job)
+    {
+        $row = [
+            'queue_name'    => $queue_name,
+            'job_name'      => $job['name'],
+            'job_params'    => json_encode($job['params'], JSON_FORCE_OBJECT),
+            'buffered_at'   => $job['meta']['buffered_at'],
+            'buffered_from' => $job['meta']['buffered_from'],
+            'inserted_from' => gethostname(),
+        ];
+
+        if (isset($job['options']['run_after'])) {
+            $row['run_after'] = $job['options']['run_after'];
+        }
+        if (isset($job['options']['job_rank'])) {
+            $row['job_rank'] = $job['options']['job_rank'];
+        }
+        if (isset($job['options']['mutex_id'])) {
+            $row['mutex_id'] = $job['options']['mutex_id'];
+        }
+
+        $this->yo_pdo->transaction()->begin('buffer-job');
+        $this->yo_pdo->insert('buffered_jobs', $row);
+        $this->yo_pdo->transaction()->accept('buffer-job');
+    }
+}

--- a/src/Hodor/Database/Adapter/Postgres/Dequeuer.php
+++ b/src/Hodor/Database/Adapter/Postgres/Dequeuer.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Hodor\Database\Adapter\Postgres;
+
+use Hodor\Database\Adapter\DequeuerInterface;
+use Hodor\Database\Exception\BufferedJobNotFoundException;
+use Lstr\YoPdo\YoPdo;
+
+class Dequeuer implements DequeuerInterface
+{
+    /**
+     * @var YoPdo
+     */
+    private $yo_pdo;
+
+    /**
+     * @param YoPdo $yo_pdo
+     */
+    public function __construct(YoPdo $yo_pdo)
+    {
+        $this->yo_pdo = $yo_pdo;
+    }
+
+    /**
+     * @param array $meta
+     */
+    public function markJobAsSuccessful(array $meta)
+    {
+        return $this->markJobAsFinished('successful', $meta);
+    }
+
+    /**
+     * @param array $meta
+     */
+    public function markJobAsFailed(array $meta)
+    {
+        return $this->markJobAsFinished('failed', $meta);
+    }
+
+    /**
+     * @param string $status
+     * @param array $meta
+     * @throws BufferedJobNotFoundException
+     */
+    private function markJobAsFinished($status, array $meta)
+    {
+        $sql = <<<SQL
+SELECT *
+FROM queued_jobs
+WHERE buffered_job_id = :buffered_job_id
+SQL;
+
+        $this->yo_pdo->transaction()->begin('dequeue-job');
+
+        $job = $this->yo_pdo->query(
+            $sql,
+            ['buffered_job_id' => $meta['buffered_job_id']]
+        )->fetch();
+
+        if (!$job) {
+            throw new BufferedJobNotFoundException(
+                "Could not mark buffered_job_id={$meta['buffered_job_id']} as finished. Job not found.",
+                $meta['buffered_job_id'],
+                $meta
+            );
+        }
+
+        $job['started_running_at'] = $meta['started_running_at'];
+        $job['ran_from'] = gethostname();
+        $job['dequeued_from'] = gethostname();
+        unset($job['queued_job_id']);
+
+        $this->yo_pdo->delete(
+            'queued_jobs',
+            'buffered_job_id = :buffered_job_id',
+            ['buffered_job_id' => $job['buffered_job_id']]
+        );
+        $this->yo_pdo->insert("{$status}_jobs", $job);
+
+        $this->yo_pdo->transaction()->accept('dequeue-job');
+    }
+}

--- a/src/Hodor/Database/Adapter/Postgres/Factory.php
+++ b/src/Hodor/Database/Adapter/Postgres/Factory.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Hodor\Database\Adapter\Postgres;
+
+use Hodor\Database\Adapter\BufferWorkerInterface;
+use Hodor\Database\Adapter\DequeuerInterface;
+use Hodor\Database\Adapter\FactoryInterface;
+use Hodor\Database\Adapter\SuperqueuerInterface;
+use Hodor\Database\Driver\YoPdoDriver;
+use Hodor\Database\PgsqlAdapter;
+use Lstr\YoPdo\YoPdo;
+
+class Factory implements FactoryInterface
+{
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @var BufferWorker
+     */
+    private $buffer_worker;
+
+    /**
+     * @var Superqueuer
+     */
+    private $superqueuer;
+
+    /**
+     * @var Dequeuer
+     */
+    private $dequeuer;
+
+    /**
+     * @var PgsqlAdapter
+     */
+    private $pgsql_adapter;
+
+    /**
+     * @var YoPdoDriver
+     */
+    private $yo_pdo_driver;
+
+    /**
+     * @param PgsqlAdapter $pgsql_adapter
+     * @param array $config
+     */
+    public function __construct(PgsqlAdapter $pgsql_adapter, array $config)
+    {
+        $this->pgsql_adapter = $pgsql_adapter;
+        $this->config = $config;
+    }
+
+    /**
+     * @return BufferWorkerInterface
+     */
+    public function getBufferWorker()
+    {
+        if ($this->buffer_worker) {
+            return $this->buffer_worker;
+        }
+
+        $this->buffer_worker = new BufferWorker($this->getYoPdo());
+
+        return $this->buffer_worker;
+    }
+
+    /**
+     * @return SuperqueuerInterface
+     */
+    public function getSuperqueuer()
+    {
+        if ($this->superqueuer) {
+            return $this->superqueuer;
+        }
+
+        $this->superqueuer = new Superqueuer($this->getYoPdo());
+
+        return $this->superqueuer;
+    }
+
+    /**
+     * @return DequeuerInterface
+     */
+    public function getDequeuer()
+    {
+        if ($this->dequeuer) {
+            return $this->dequeuer;
+        }
+
+        $this->dequeuer = new Dequeuer($this->getYoPdo());
+
+        return $this->dequeuer;
+    }
+
+    /**
+     * @return YoPdoDriver
+     * @deprecated
+     */
+    public function getYoPdoDriver()
+    {
+        if ($this->yo_pdo_driver) {
+            return $this->yo_pdo_driver;
+        }
+
+        $this->yo_pdo_driver = new YoPdoDriver($this->config);
+
+        return $this->yo_pdo_driver;
+    }
+
+    /**
+     * @return PgsqlAdapter
+     */
+    public function getPgsqlAdapter()
+    {
+        return $this->pgsql_adapter;
+    }
+
+    /**
+     * @return YoPdo
+     */
+    private function getYoPdo()
+    {
+        return $this->getYoPdoDriver()->getYoPdo();
+    }
+}

--- a/src/Hodor/Database/Adapter/Postgres/Superqueuer.php
+++ b/src/Hodor/Database/Adapter/Postgres/Superqueuer.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Hodor\Database\Adapter\Postgres;
+
+use Generator;
+use Hodor\Database\Adapter\SuperqueuerInterface;
+use Lstr\YoPdo\YoPdo;
+
+class Superqueuer implements SuperqueuerInterface
+{
+    /**
+     * @var YoPdo
+     */
+    private $yo_pdo;
+
+    /**
+     * @param YoPdo $yo_pdo
+     */
+    public function __construct(YoPdo $yo_pdo)
+    {
+        $this->yo_pdo = $yo_pdo;
+    }
+
+    /**
+     * @param string $category
+     * @param string $name
+     * @return bool
+     */
+    public function requestAdvisoryLock($category, $name)
+    {
+        $category_crc = crc32($category) - 0x80000000;
+        $name_crc = crc32($name) - 0x80000000;
+
+        $row = $this->yo_pdo->query(
+            'SELECT pg_try_advisory_lock(:category_crc, :name_crc) AS is_granted',
+            [
+                'category_crc' => $category_crc,
+                'name_crc'     => $name_crc,
+            ]
+        )->fetch();
+
+        return $row['is_granted'];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getJobsToRunGenerator()
+    {
+        $sql = <<<SQL
+WITH mutexed_buffered_jobs AS (
+    SELECT
+        buffered_jobs.*,
+        RANK() OVER (
+            PARTITION BY mutex_id
+            ORDER BY job_rank, buffered_at, buffered_job_id
+        ) AS mutex_rank
+    FROM buffered_jobs
+    WHERE run_after <= NOW()
+        AND NOT EXISTS (
+            SELECT 1
+            FROM queued_jobs
+            WHERE queued_jobs.mutex_id = buffered_jobs.mutex_id
+        )
+    ORDER BY
+        job_rank,
+        buffered_at
+)
+SELECT *
+FROM mutexed_buffered_jobs
+WHERE mutex_rank = 1
+ORDER BY
+    job_rank,
+    buffered_at
+SQL;
+
+        $row_generator = $this->yo_pdo->getSelectRowGenerator($sql);
+        foreach ($row_generator as $job) {
+            $job['job_params'] = json_decode($job['job_params'], true);
+            yield $job;
+        }
+    }
+
+    public function beginBatch()
+    {
+        $this->yo_pdo->transaction()->begin('superqueue-jobs');
+    }
+
+    /**
+     * @param array $job
+     * @return array
+     */
+    public function markJobAsQueued(array $job)
+    {
+        $this->yo_pdo->delete(
+            'buffered_jobs',
+            'buffered_job_id = :buffered_job_id',
+            ['buffered_job_id' => $job['buffered_job_id']]
+        );
+        $job['job_params'] = json_encode($job['job_params'], JSON_FORCE_OBJECT);
+        $job['superqueued_from'] = gethostname();
+        $this->yo_pdo->insert(
+            'queued_jobs',
+            [
+                'buffered_job_id'  => $job['buffered_job_id'],
+                'queue_name'       => $job['queue_name'],
+                'job_name'         => $job['job_name'],
+                'job_params'       => $job['job_params'],
+                'job_rank'         => $job['job_rank'],
+                'run_after'        => $job['run_after'],
+                'buffered_at'      => $job['buffered_at'],
+                'buffered_from'    => $job['buffered_from'],
+                'inserted_at'      => $job['inserted_at'],
+                'inserted_from'    => $job['inserted_from'],
+                'superqueued_from' => $job['superqueued_from'],
+                'mutex_id'         => $job['mutex_id'],
+            ]
+        );
+
+        return ['buffered_job_id' => $job['buffered_job_id']];
+    }
+
+    public function publishBatch()
+    {
+        $this->yo_pdo->transaction()->accept('superqueue-jobs');
+    }
+}

--- a/src/Hodor/Database/Adapter/Testing/BufferWorker.php
+++ b/src/Hodor/Database/Adapter/Testing/BufferWorker.php
@@ -29,11 +29,6 @@ class BufferWorker implements BufferWorkerInterface
 
         $job = array_replace_recursive([
             'name' => "job-name-{$job_id}",
-            'params' => [],
-            'meta' => [
-                'buffered_at'   => date('c'),
-                'buffered_from' => gethostname(),
-            ],
             'options' => [
                 'run_after' => date('c'),
                 'job_rank'  => 5,

--- a/src/Hodor/Database/Driver/YoPdoDriver.php
+++ b/src/Hodor/Database/Driver/YoPdoDriver.php
@@ -84,7 +84,7 @@ class YoPdoDriver
     /**
      * @return YoPdo
      */
-    private function getYoPdo()
+    public function getYoPdo()
     {
         if ($this->yo_pdo) {
             return $this->yo_pdo;

--- a/src/Hodor/Database/PgsqlAdapter.php
+++ b/src/Hodor/Database/PgsqlAdapter.php
@@ -2,17 +2,21 @@
 
 namespace Hodor\Database;
 
-use Generator;
+use Hodor\Database\Adapter\Postgres\Factory;
 use Hodor\Database\Driver\YoPdoDriver;
-use Hodor\Database\Exception\BufferedJobNotFoundException;
 use Hodor\Database\Phpmig\PgsqlPhpmigAdapter;
 
-class PgsqlAdapter implements AdapterInterface
+class PgsqlAdapter extends ConverterAdapter
 {
     /**
      * @var array
      */
     private $config;
+
+    /**
+     * @var Factory
+     */
+    private $postgres_factory;
 
     /**
      * @var YoPdoDriver
@@ -25,125 +29,9 @@ class PgsqlAdapter implements AdapterInterface
     public function __construct(array $config)
     {
         $this->config = $config;
-    }
+        $this->postgres_factory = new Factory($this, $config);
 
-    /**
-     * @param string $queue_name
-     * @param array $job
-     */
-    public function bufferJob($queue_name, array $job)
-    {
-        $row = [
-            'queue_name'    => $queue_name,
-            'job_name'      => $job['name'],
-            'job_params'    => json_encode($job['params'], JSON_FORCE_OBJECT),
-            'buffered_at'   => $job['meta']['buffered_at'],
-            'buffered_from' => $job['meta']['buffered_from'],
-            'inserted_from' => gethostname(),
-        ];
-
-        if (isset($job['options']['run_after'])) {
-            $row['run_after'] = $job['options']['run_after'];
-        }
-        if (isset($job['options']['job_rank'])) {
-            $row['job_rank'] = $job['options']['job_rank'];
-        }
-        if (isset($job['options']['mutex_id'])) {
-            $row['mutex_id'] = $job['options']['mutex_id'];
-        }
-
-        $this->beginTransaction();
-        $this->getDriver()->insert('buffered_jobs', $row);
-        $this->commitTransaction();
-    }
-
-    /**
-     * @return Generator
-     */
-    public function getJobsToRunGenerator()
-    {
-        $sql = <<<SQL
-WITH mutexed_buffered_jobs AS (
-    SELECT
-        buffered_jobs.*,
-        RANK() OVER (
-            PARTITION BY mutex_id
-            ORDER BY job_rank, buffered_at, buffered_job_id
-        ) AS mutex_rank
-    FROM buffered_jobs
-    WHERE run_after <= NOW()
-        AND NOT EXISTS (
-            SELECT 1
-            FROM queued_jobs
-            WHERE queued_jobs.mutex_id = buffered_jobs.mutex_id
-        )
-    ORDER BY
-        job_rank,
-        buffered_at
-)
-SELECT *
-FROM mutexed_buffered_jobs
-WHERE mutex_rank = 1
-ORDER BY
-    job_rank,
-    buffered_at
-SQL;
-
-        $row_generator = $this->getDriver()->selectRowGenerator($sql);
-        foreach ($row_generator as $job) {
-            $job['job_params'] = json_decode($job['job_params'], true);
-            yield $job;
-        }
-    }
-
-    /**
-     * @param array $job
-     * @return array
-     */
-    public function markJobAsQueued(array $job)
-    {
-        $this->getDriver()->delete(
-            'buffered_jobs',
-            'buffered_job_id = :buffered_job_id',
-            ['buffered_job_id' => $job['buffered_job_id']]
-        );
-        $job['job_params'] = json_encode($job['job_params'], JSON_FORCE_OBJECT);
-        $job['superqueued_from'] = gethostname();
-        $this->getDriver()->insert(
-            'queued_jobs',
-            [
-                'buffered_job_id'  => $job['buffered_job_id'],
-                'queue_name'       => $job['queue_name'],
-                'job_name'         => $job['job_name'],
-                'job_params'       => $job['job_params'],
-                'job_rank'         => $job['job_rank'],
-                'run_after'        => $job['run_after'],
-                'buffered_at'      => $job['buffered_at'],
-                'buffered_from'    => $job['buffered_from'],
-                'inserted_at'      => $job['inserted_at'],
-                'inserted_from'    => $job['inserted_from'],
-                'superqueued_from' => $job['superqueued_from'],
-                'mutex_id'         => $job['mutex_id'],
-            ]
-        );
-
-        return ['buffered_job_id' => $job['buffered_job_id']];
-    }
-
-    /**
-     * @param array $meta
-     */
-    public function markJobAsSuccessful(array $meta)
-    {
-        return $this->markJobAsFinished('successful', $meta);
-    }
-
-    /**
-     * @param array $meta
-     */
-    public function markJobAsFailed(array $meta)
-    {
-        return $this->markJobAsFinished('failed', $meta);
+        parent::__construct($this->postgres_factory);
     }
 
     /**
@@ -152,37 +40,6 @@ SQL;
     public function getPhpmigAdapter()
     {
         return new PgsqlPhpmigAdapter($this->getDriver());
-    }
-
-    public function beginTransaction()
-    {
-        $this->queryMultiple('BEGIN');
-    }
-
-    public function commitTransaction()
-    {
-        $this->queryMultiple('COMMIT');
-    }
-
-    /**
-     * @param $category
-     * @param $name
-     * @return bool
-     */
-    public function requestAdvisoryLock($category, $name)
-    {
-        $category_crc = crc32($category) - 0x80000000;
-        $name_crc = crc32($name) - 0x80000000;
-
-        $row = $this->getDriver()->selectOne(
-            'SELECT pg_try_advisory_lock(:category_crc, :name_crc) AS is_granted',
-            [
-                'category_crc' => $category_crc,
-                'name_crc'     => $name_crc,
-            ]
-        );
-
-        return $row['is_granted'];
     }
 
     /**
@@ -195,48 +52,6 @@ SQL;
     }
 
     /**
-     * @param $status
-     * @param array $meta
-     */
-    private function markJobAsFinished($status, array $meta)
-    {
-        $sql = <<<SQL
-SELECT *
-FROM queued_jobs
-WHERE buffered_job_id = :buffered_job_id
-SQL;
-
-        $this->beginTransaction();
-
-        $job = $this->getDriver()->selectOne(
-            $sql,
-            ['buffered_job_id' => $meta['buffered_job_id']]
-        );
-
-        if (!$job) {
-            throw new BufferedJobNotFoundException(
-                "Could not mark buffered_job_id={$meta['buffered_job_id']} as finished. Job not found.",
-                $meta['buffered_job_id'],
-                $meta
-            );
-        }
-
-        $job['started_running_at'] = $meta['started_running_at'];
-        $job['ran_from'] = gethostname();
-        $job['dequeued_from'] = gethostname();
-        unset($job['queued_job_id']);
-
-        $this->getDriver()->delete(
-            'queued_jobs',
-            'buffered_job_id = :buffered_job_id',
-            ['buffered_job_id' => $job['buffered_job_id']]
-        );
-        $this->getDriver()->insert("{$status}_jobs", $job);
-
-        $this->commitTransaction();
-    }
-
-    /**
      * @return YoPdoDriver
      */
     private function getDriver()
@@ -245,7 +60,7 @@ SQL;
             return $this->driver;
         }
 
-        $this->driver = new YoPdoDriver($this->config);
+        $this->driver = $this->postgres_factory->getYoPdoDriver();
 
         return $this->driver;
     }

--- a/tests/src/Hodor/Database/AbstractAdapterTest.php
+++ b/tests/src/Hodor/Database/AbstractAdapterTest.php
@@ -171,6 +171,10 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
 
         unset($connections[0]);
 
+        // without forcing garbage collection, the DB connections
+        // are not guaranteed to be disconnected; force GC
+        gc_collect_cycles();
+
         $this->assertTrue($connections[2]->requestAdvisoryLock('test', 'lock'));
     }
 

--- a/tests/src/Hodor/Database/AbstractAdapterTest.php
+++ b/tests/src/Hodor/Database/AbstractAdapterTest.php
@@ -23,8 +23,11 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
      * @covers ::getJobsToRunGenerator
      * @covers ::<private>
      * @covers Hodor\Database\Adapter\Testing\BufferWorker::__construct
+     * @covers Hodor\Database\Adapter\Postgres\BufferWorker::__construct
      * @covers Hodor\Database\Adapter\Testing\BufferWorker::bufferJob
+     * @covers Hodor\Database\Adapter\Postgres\BufferWorker::bufferJob
      * @covers Hodor\Database\Adapter\Testing\BufferWorker::<private>
+     * @covers Hodor\Database\Adapter\Postgres\BufferWorker::<private>
      * @param array $buffered_jobs
      * @param array $expected_jobs
      * @dataProvider provideBufferJobsScenarios
@@ -43,9 +46,13 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
      * @covers ::getJobsToRunGenerator
      * @covers ::<private>
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::__construct
+     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::__construct
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::getJobsToRunGenerator
+     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::getJobsToRunGenerator
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::markJobAsQueued
+     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::markJobAsQueued
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::<private>
+     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::<private>
      * @param array $buffered_jobs
      * @param array $queued_jobs
      * @param array $expected_jobs
@@ -64,8 +71,11 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
      * @covers ::markJobAsSuccessful
      * @covers ::<private>
      * @covers Hodor\Database\Adapter\Testing\Dequeuer::__construct
+     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::__construct
      * @covers Hodor\Database\Adapter\Testing\Dequeuer::markJobAsSuccessful
+     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::markJobAsSuccessful
      * @covers Hodor\Database\Adapter\Testing\Dequeuer::<private>
+     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::<private>
      */
     public function testJobCanBeMarkedAsSuccessful()
     {
@@ -78,8 +88,11 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
      * @covers ::markJobAsFailed
      * @covers ::<private>
      * @covers Hodor\Database\Adapter\Testing\Dequeuer::__construct
+     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::__construct
      * @covers Hodor\Database\Adapter\Testing\Dequeuer::markJobAsFailed
+     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::markJobAsFailed
      * @covers Hodor\Database\Adapter\Testing\Dequeuer::<private>
+     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::<private>
      */
     public function testJobCanBeMarkedAsFailed()
     {
@@ -92,8 +105,11 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
      * @covers ::markJobAsSuccessful
      * @covers ::<private>
      * @covers Hodor\Database\Adapter\Testing\Dequeuer::__construct
+     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::__construct
      * @covers Hodor\Database\Adapter\Testing\Dequeuer::markJobAsSuccessful
+     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::markJobAsSuccessful
      * @covers Hodor\Database\Adapter\Testing\Dequeuer::<private>
+     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::<private>
      * @expectedException Hodor\Database\Exception\BufferedJobNotFoundException
      */
     public function testMarkingUnrecognizedJobAsSuccessfulTriggersAnException()
@@ -105,8 +121,11 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
      * @covers ::markJobAsFailed
      * @covers ::<private>
      * @covers Hodor\Database\Adapter\Testing\Dequeuer::__construct
+     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::__construct
      * @covers Hodor\Database\Adapter\Testing\Dequeuer::markJobAsFailed
+     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::markJobAsFailed
      * @covers Hodor\Database\Adapter\Testing\Dequeuer::<private>
+     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::<private>
      * @expectedException Hodor\Database\Exception\BufferedJobNotFoundException
      */
     public function testMarkingUnrecognizedJobAsFailedTriggersAnException()
@@ -118,11 +137,20 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
      * @covers ::beginTransaction
      * @covers ::commitTransaction
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::__construct
+     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::__construct
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::getJobsToRunGenerator
+     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::getJobsToRunGenerator
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::beginBatch
+     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::beginBatch
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::markJobAsQueued
+     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::markJobAsQueued
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::publishBatch
+     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::publishBatch
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::<private>
+     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::<private>
+     * @covers Hodor\Database\PgsqlAdapter::queryMultiple
+     * @covers Hodor\Database\PgsqlAdapter::beginTransaction
+     * @covers Hodor\Database\PgsqlAdapter::commitTransaction
      */
     public function testQueueingJobsCanBeBatched()
     {
@@ -154,9 +182,12 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::requestAdvisoryLock
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::__construct
+     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::__construct
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::__destruct
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::requestAdvisoryLock
+     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::requestAdvisoryLock
      * @covers Hodor\Database\Adapter\Testing\Superqueuer::<private>
+     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::<private>
      */
     public function testAdvisoryLockCanBeAcquired()
     {

--- a/tests/src/Hodor/Database/Adapter/FactoryTest.php
+++ b/tests/src/Hodor/Database/Adapter/FactoryTest.php
@@ -23,14 +23,14 @@ abstract class FactoryTest extends PHPUnit_Framework_TestCase
 
         $uniqid = uniqid();
 
-        $buffer_worker->bufferJob('fast_jobs', [
+        $buffer_worker->bufferJob('fast_jobs', $this->getJob([
             'name'    => "job-{$uniqid}-1",
             'options' => ['mutex_id' => "mutex-{$uniqid}"],
-        ]);
-        $buffer_worker->bufferJob('fast_jobs', [
+        ]));
+        $buffer_worker->bufferJob('fast_jobs', $this->getJob([
             'name'    => "job-{$uniqid}-2",
             'options' => ['mutex_id' => "mutex-{$uniqid}"],
-        ]);
+        ]));
 
         $job_to_finish = null;
         foreach ($superqueuer->getJobsToRunGenerator() as $job) {
@@ -90,4 +90,19 @@ abstract class FactoryTest extends PHPUnit_Framework_TestCase
      * @return FactoryInterface
      */
     abstract protected function getTestFactory();
+
+    /**
+     * @param array $job
+     * @return array
+     */
+    private function getJob(array $job)
+    {
+        return array_replace_recursive([
+            'params' => [],
+            'meta' => [
+                'buffered_at'   => date('c'),
+                'buffered_from' => gethostname(),
+            ],
+        ], $job);
+    }
 }

--- a/tests/src/Hodor/Database/Adapter/FactoryTest.php
+++ b/tests/src/Hodor/Database/Adapter/FactoryTest.php
@@ -37,6 +37,7 @@ abstract class FactoryTest extends PHPUnit_Framework_TestCase
             $this->assertSame("job-{$uniqid}-1", $job['job_name']);
             $superqueuer->markJobAsQueued($job);
             $job_to_finish = $job;
+            $job_to_finish['started_running_at'] = date('c');
         }
 
         foreach ($superqueuer->getJobsToRunGenerator() as $job) {

--- a/tests/src/Hodor/Database/Adapter/Postgres/FactoryTest.php
+++ b/tests/src/Hodor/Database/Adapter/Postgres/FactoryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Hodor\Database\Adapter\Postgres;
+
+use Exception;
+use Hodor\Database\Adapter\FactoryInterface;
+use Hodor\Database\Adapter\FactoryTest as FactoryBaseTest;
+use Hodor\Database\PgsqlAdapter;
+use Hodor\Database\Phpmig\CommandWrapper;
+use Hodor\Database\Phpmig\Container;
+use Symfony\Component\Console\Output\NullOutput;
+
+/**
+ * @coversDefaultClass \Hodor\Database\Adapter\Postgres\Factory
+ */
+class FactoryTest extends FactoryBaseTest
+{
+    /**
+     * @var Factory
+     */
+    private $factory;
+
+    public function setUp()
+    {
+        $phpmig_container = new Container();
+        $phpmig_container->addDefaultServices('no-config-file');
+        $phpmig_container['hodor.database'] = $this->getTestFactory()->getPgsqlAdapter();
+
+        $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
+        $command_wrapper->rollbackMigrations();
+        $command_wrapper->runMigrations();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->factory = null;
+
+        // without forcing garbage collection, the DB connections
+        // are not guaranteed to be disconnected; force GC
+        gc_collect_cycles();
+    }
+
+    /**
+     * @return Factory
+     * @throws Exception
+     */
+    protected function getTestFactory()
+    {
+        if ($this->factory) {
+            return $this->factory;
+        }
+
+        $this->factory = $this->generateTestFactory();
+
+        return $this->factory;
+    }
+
+    /**
+     * @return Factory
+     * @throws Exception
+     */
+    private function generateTestFactory()
+    {
+        $config_path = __DIR__ . '/../../../../../../config/config.test.php';
+        if (!file_exists($config_path)) {
+            throw new Exception("'{$config_path}' not found");
+        }
+
+        $config = require $config_path;
+
+        return new Factory(
+            new PgsqlAdapter($config['test']['db']['yo-pdo-pgsql']),
+            $config['test']['db']['yo-pdo-pgsql']
+        );
+    }
+}

--- a/tests/src/Hodor/Database/DriverTest.php
+++ b/tests/src/Hodor/Database/DriverTest.php
@@ -220,6 +220,34 @@ SQL;
     }
 
     /**
+     * @covers ::__construct
+     * @covers ::getYoPdo
+     */
+    public function testYoPdoCanBeUsed()
+    {
+        $adapter = $this->getYoPdoDriver();
+
+        $this->assertSame(
+            ['col' => 1],
+            $adapter->getYoPdo()->query('SELECT 1 AS col')->fetch()
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getYoPdo
+     */
+    public function testYoPdoIsReused()
+    {
+        $adapter = $this->getYoPdoDriver();
+
+        $this->assertSame(
+            $adapter->getYoPdo(),
+            $adapter->getYoPdo()
+        );
+    }
+
+    /**
      * @return YoPdoDriver
      * @throws Exception
      */

--- a/tests/src/Hodor/Database/PgsqlAdapterTest.php
+++ b/tests/src/Hodor/Database/PgsqlAdapterTest.php
@@ -34,16 +34,6 @@ class PgsqlAdapterTest extends AbstractAdapterTest
     }
 
     /**
-     * @covers ::beginTransaction
-     * @covers ::commitTransaction
-     * @covers ::queryMultiple
-     */
-    public function testQueueingJobsCanBeBatched()
-    {
-        parent::testQueueingJobsCanBeBatched();
-    }
-
-    /**
      * @covers ::getPhpmigAdapter
      */
     public function testPhpmigAdapterCanBeRetrieved()

--- a/tests/src/Hodor/FlowTest.php
+++ b/tests/src/Hodor/FlowTest.php
@@ -40,7 +40,12 @@ class FlowTest extends PHPUnit_Framework_TestCase
         if (file_exists($this->config_file)) {
             unlink($this->config_file);
         }
+
         unset($this->db_adapter);
+        // without forcing garbage collection, the DB connections
+        // are not guaranteed to be disconnected; force GC
+        gc_collect_cycles();
+
         $this->runCommand("psql -c 'drop database if exists {$this->db_name};' -h {$this->e_db_host} -U postgres");
     }
 


### PR DESCRIPTION
Introduce new Hodor\Database\Adapter\Postgres classes
to break down PgsqlAdapter into smaller classes that
each have less areas of responsibility than the original
monolithic-like class.

Going forward this will allow us to pass a specific DB adapter
object and a specific MQ adapter object to a worker
(i.e. buffer worker, superqueue worker, job worker, dequeuer worker)
object and more adequately test the specific functionality of
that type of worker.
