### PR TITLE
Eliminate unused variable in DriverTest

### DIFF
--- a/src/Hodor/Database/Driver/YoPdoDriver.php
+++ b/src/Hodor/Database/Driver/YoPdoDriver.php
@@ -2,6 +2,7 @@
 
 namespace Hodor\Database\Driver;
 
+use Generator;
 use Lstr\YoPdo\Factory as YoPdoFactory;
 use Lstr\YoPdo\YoPdo;
 
@@ -36,7 +37,7 @@ class YoPdoDriver
 
     /**
      * @param  string $sql
-     * @return generator
+     * @return Generator
      */
     public function selectRowGenerator($sql)
     {

--- a/tests/src/Hodor/Database/DriverTest.php
+++ b/tests/src/Hodor/Database/DriverTest.php
@@ -82,10 +82,7 @@ SQL;
 SELECT 1 FROM not_here;
 SQL;
 
-        foreach ($adapter->selectRowGenerator($sql) as $row) {
-            // an exception will be thrown as soon as
-            // we try to retrieve the results
-        }
+        iterator_to_array($adapter->selectRowGenerator($sql));
     }
 
     /**


### PR DESCRIPTION
Thanks @zacharyrankin. Now I know how to avoid
a loop to process a needless generator.
