### PR TITLE
Make DB adapter factory type hints more specific

### DIFF
--- a/src/Hodor/Database/Adapter/Postgres/Factory.php
+++ b/src/Hodor/Database/Adapter/Postgres/Factory.php
@@ -2,10 +2,7 @@
 
 namespace Hodor\Database\Adapter\Postgres;
 
-use Hodor\Database\Adapter\BufferWorkerInterface;
-use Hodor\Database\Adapter\DequeuerInterface;
 use Hodor\Database\Adapter\FactoryInterface;
-use Hodor\Database\Adapter\SuperqueuerInterface;
 use Hodor\Database\Driver\YoPdoDriver;
 use Hodor\Database\PgsqlAdapter;
 use Lstr\YoPdo\YoPdo;
@@ -53,7 +50,7 @@ class Factory implements FactoryInterface
     }
 
     /**
-     * @return BufferWorkerInterface
+     * @return BufferWorker
      */
     public function getBufferWorker()
     {
@@ -67,7 +64,7 @@ class Factory implements FactoryInterface
     }
 
     /**
-     * @return SuperqueuerInterface
+     * @return Superqueuer
      */
     public function getSuperqueuer()
     {
@@ -81,7 +78,7 @@ class Factory implements FactoryInterface
     }
 
     /**
-     * @return DequeuerInterface
+     * @return Dequeuer
      */
     public function getDequeuer()
     {

--- a/src/Hodor/Database/Adapter/Testing/Factory.php
+++ b/src/Hodor/Database/Adapter/Testing/Factory.php
@@ -2,10 +2,7 @@
 
 namespace Hodor\Database\Adapter\Testing;
 
-use Hodor\Database\Adapter\BufferWorkerInterface;
-use Hodor\Database\Adapter\DequeuerInterface;
 use Hodor\Database\Adapter\FactoryInterface;
-use Hodor\Database\Adapter\SuperqueuerInterface;
 
 class Factory implements FactoryInterface
 {
@@ -45,7 +42,7 @@ class Factory implements FactoryInterface
     }
 
     /**
-     * @return BufferWorkerInterface
+     * @return BufferWorker
      */
     public function getBufferWorker()
     {
@@ -59,7 +56,7 @@ class Factory implements FactoryInterface
     }
 
     /**
-     * @return SuperqueuerInterface
+     * @return Superqueuer
      */
     public function getSuperqueuer()
     {
@@ -73,7 +70,7 @@ class Factory implements FactoryInterface
     }
 
     /**
-     * @return DequeuerInterface
+     * @return Dequeuer
      */
     public function getDequeuer()
     {


### PR DESCRIPTION
More specific type hints may result in better code
completion and reduces the number of class/interfaces
directly depended on.
