### PR TITLE
Remove getSuperqueueConfig()

### DIFF
--- a/src/Hodor/JobQueue/Config.php
+++ b/src/Hodor/JobQueue/Config.php
@@ -76,14 +76,6 @@ class Config implements ConfigInterface
     }
 
     /**
-     * @return array
-     */
-    public function getSuperqueueConfig()
-    {
-        return $this->getOption('superqueue');
-    }
-
-    /**
      * @param  string $queue_name
      * @return array
      */

--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -170,10 +170,10 @@ class QueueManager
             return $this->database;
         }
 
-        $config = $this->config->getSuperqueueConfig();
-        $db_adapter_factory = new DbAdapterFactory($config['database']);
+        $config = $this->config->getDatabaseConfig();
+        $db_adapter_factory = new DbAdapterFactory($config);
 
-        $this->database = $db_adapter_factory->getAdapter($config['database']['type']);
+        $this->database = $db_adapter_factory->getAdapter($config['type']);
 
         return $this->database;
     }

--- a/tests/src/Hodor/JobQueue/ConfigTest.php
+++ b/tests/src/Hodor/JobQueue/ConfigTest.php
@@ -29,17 +29,6 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers ::__construct
-     * @covers ::getSuperqueueConfig
-     */
-    public function testSuperqueueConfigCanBeRetrieved()
-    {
-        $config = new Config(__FILE__, ['superqueue' => 'heya']);
-
-        $this->assertEquals('heya', $config->getSuperqueueConfig());
-    }
-
-    /**
-     * @covers ::__construct
      * @covers ::getDatabaseConfig
      * @dataProvider configProvider
      */


### PR DESCRIPTION
The superqueue config has nothing in it but
the database config, so for now let's use
the getDatabaseConfig() method and get rid of
the unneeded method
