### PR TITLE
Keep DB adapter configuration altogether

### DIFF
--- a/src/Hodor/Database/AdapterFactory.php
+++ b/src/Hodor/Database/AdapterFactory.php
@@ -14,25 +14,19 @@ class AdapterFactory
     ];
 
     /**
-     * @var array
-     */
-    private $config;
-
-    /**
-     * @param array $config
-     */
-    public function __construct(array $config)
-    {
-        $this->config = $config;
-    }
-
-    /**
-     * @param  string $name
+     * @param  array $config
      * @return AdapterInterface
      * @throws Exception
      */
-    public function getAdapter($name)
+    public function getAdapter(array $config)
     {
+        if (empty($config['type'])) {
+            throw new Exception(
+                "The database connection 'type' must provided in connection config."
+            );
+        }
+
+        $name = $config['type'];
         if (!isset($this->adapter_factories[$name])) {
             throw new Exception(
                 "A database adapter factory is not associated with '{$name}'."
@@ -41,6 +35,6 @@ class AdapterFactory
 
         $adapter_class = $this->adapter_factories[$name];
 
-        return new $adapter_class($this->config);
+        return new $adapter_class($config);
     }
 }

--- a/src/Hodor/Database/Phpmig/Container.php
+++ b/src/Hodor/Database/Phpmig/Container.php
@@ -36,8 +36,8 @@ class Container extends Pimple
         );
 
         $this['hodor.database.factory'] = $this->share(
-            function (Pimple $container) {
-                return new DbFactory($container['hodor.database.config']);
+            function () {
+                return new DbFactory();
             }
         );
 
@@ -46,7 +46,7 @@ class Container extends Pimple
                 $db_factory = $container['hodor.database.factory'];
                 $db_config = $container['hodor.database.config'];
 
-                return $db_factory->getAdapter($db_config['type']);
+                return $db_factory->getAdapter($db_config);
             }
         );
 

--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -171,9 +171,9 @@ class QueueManager
         }
 
         $config = $this->config->getDatabaseConfig();
-        $db_adapter_factory = new DbAdapterFactory($config);
+        $db_adapter_factory = new DbAdapterFactory();
 
-        $this->database = $db_adapter_factory->getAdapter($config['type']);
+        $this->database = $db_adapter_factory->getAdapter($config);
 
         return $this->database;
     }

--- a/tests/src/Hodor/Database/AdapterFactoryTest.php
+++ b/tests/src/Hodor/Database/AdapterFactoryTest.php
@@ -9,34 +9,44 @@ use PHPUnit_Framework_TestCase;
  */
 class AdapterFactoryTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var AdapterFactory
+     */
     private $adapter_factory;
 
     public function setUp()
     {
         parent::setUp();
 
-        $this->adapter_factory = new AdapterFactory([]);
+        $this->adapter_factory = new AdapterFactory();
     }
 
     /**
-     * @covers ::__construct
      * @covers ::getAdapter
      * @expectedException \Exception
      */
-    public function testRequestingAnAdapterForUnknownNameThrowsAnException()
+    public function testRequestingAnAdapterWithoutProvidingATypeThrowsAnException()
     {
-        $this->adapter_factory->getAdapter('unk');
+        $this->adapter_factory->getAdapter([]);
     }
 
     /**
-     * @covers ::__construct
+     * @covers ::getAdapter
+     * @expectedException \Exception
+     */
+    public function testRequestingAnAdapterForUnknownTypeThrowsAnException()
+    {
+        $this->adapter_factory->getAdapter(['type' => 'unk']);
+    }
+
+    /**
      * @covers ::getAdapter
      */
     public function testAdapterForPgsqlNameIsAPgsqlAdapter()
     {
         $this->assertInstanceOf(
             '\Hodor\Database\PgsqlAdapter',
-            $this->adapter_factory->getAdapter('pgsql')
+            $this->adapter_factory->getAdapter(['type' => 'pgsql'])
         );
     }
 }


### PR DESCRIPTION
Rather than having the DB adapter configuration passed
into the constructor and then still require a type be
passed to getAdapter(), send the entire configuration to
getAdapter() and nothing to the constructor.
