### PR TITLE
Move callable factories to new JobQueueConfig

### DIFF
--- a/bin/job-worker.php
+++ b/bin/job-worker.php
@@ -15,4 +15,4 @@ $config = Config::loadFromFile($config_file);
 $queue_manager = new QueueManager($config);
 $worker_queue = $queue_manager->getWorkerQueue($queue_name);
 
-$worker_queue->runNext($config->getJobRunnerFactory());
+$worker_queue->runNext($config->getJobQueueConfig()->getJobRunnerFactory());

--- a/src/Hodor/JobQueue/Config/JobQueueConfig.php
+++ b/src/Hodor/JobQueue/Config/JobQueueConfig.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Hodor\JobQueue\Config;
+
+use Exception;
+
+class JobQueueConfig
+{
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config)
+    {
+        $this->config = array_merge(
+            [
+                'job_runner'                => null,
+                'worker_queue_name_factory' => null,
+                'buffer_queue_name_factory' => null,
+            ],
+            $config
+        );
+    }
+
+    /**
+     * @return callable
+     * @throws Exception
+     */
+    public function getJobRunnerFactory()
+    {
+        $job_runner = $this->config['job_runner'];
+
+        if (empty($job_runner)) {
+            throw new Exception("The 'job_runner' config parameter is required.");
+        } elseif (!is_callable($job_runner)) {
+            throw new Exception(
+                "The provided 'job_runner' config value is not a callable."
+            );
+        }
+
+        return $job_runner;
+    }
+
+    /**
+     * @return callable
+     * @throws Exception
+     */
+    public function getWorkerQueueNameFactory()
+    {
+        $worker_queue_name_factory = $this->config['worker_queue_name_factory'];
+
+        if (empty($worker_queue_name_factory)) {
+            $worker_queue_name_factory = function ($name, $params, $options) {
+                if (empty($options['queue_name'])) {
+                    throw new Exception(
+                        "Job option 'queue_name' is required when using the "
+                        . "default queue name factory."
+                    );
+                }
+                return $options['queue_name'];
+            };
+        } elseif (!is_callable($worker_queue_name_factory)) {
+            throw new Exception(
+                "The provided 'worker_queue_name_factory' config value is not a callable."
+            );
+        }
+
+        return $worker_queue_name_factory;
+    }
+
+    /**
+     * @return callable
+     * @throws Exception
+     */
+    public function getBufferQueueNameFactory()
+    {
+        $buffer_queue_name_factory = $this->config['buffer_queue_name_factory'];
+
+        if (empty($buffer_queue_name_factory)) {
+            $buffer_queue_name_factory = function ($name, $params, $options) {
+                return 'default';
+            };
+        } elseif (!is_callable($buffer_queue_name_factory)) {
+            throw new Exception(
+                "The provided 'buffer_queue_name_factory' config value is not a callable."
+            );
+        }
+
+        return $buffer_queue_name_factory;
+    }
+}

--- a/src/Hodor/JobQueue/Config/JobQueueConfig.php
+++ b/src/Hodor/JobQueue/Config/JobQueueConfig.php
@@ -51,10 +51,11 @@ class JobQueueConfig
      */
     public function getWorkerQueueNameFactory()
     {
-        $worker_queue_name_factory = $this->config['worker_queue_name_factory'];
+        $worker_qname_factory = $this->config['worker_queue_name_factory'];
 
-        if (empty($worker_queue_name_factory)) {
-            $worker_queue_name_factory = function ($name, $params, $options) {
+        if (empty($worker_qname_factory)) {
+            $worker_qname_factory = function ($name, $params, $options) {
+                unset($name, $params);
                 if (empty($options['queue_name'])) {
                     throw new Exception(
                         "Job option 'queue_name' is required when using the "
@@ -63,13 +64,13 @@ class JobQueueConfig
                 }
                 return $options['queue_name'];
             };
-        } elseif (!is_callable($worker_queue_name_factory)) {
+        } elseif (!is_callable($worker_qname_factory)) {
             throw new Exception(
                 "The provided 'worker_queue_name_factory' config value is not a callable."
             );
         }
 
-        return $worker_queue_name_factory;
+        return $worker_qname_factory;
     }
 
     /**
@@ -78,18 +79,19 @@ class JobQueueConfig
      */
     public function getBufferQueueNameFactory()
     {
-        $buffer_queue_name_factory = $this->config['buffer_queue_name_factory'];
+        $buffer_qname_factory = $this->config['buffer_queue_name_factory'];
 
-        if (empty($buffer_queue_name_factory)) {
-            $buffer_queue_name_factory = function ($name, $params, $options) {
+        if (empty($buffer_qname_factory)) {
+            $buffer_qname_factory = function ($name, $params, $options) {
+                unset($name, $params, $options);
                 return 'default';
             };
-        } elseif (!is_callable($buffer_queue_name_factory)) {
+        } elseif (!is_callable($buffer_qname_factory)) {
             throw new Exception(
                 "The provided 'buffer_queue_name_factory' config value is not a callable."
             );
         }
 
-        return $buffer_queue_name_factory;
+        return $buffer_qname_factory;
     }
 }

--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -89,7 +89,7 @@ class QueueManager
     public function getBufferQueueForJob($name, array $params, array $options)
     {
         $queue_name = call_user_func(
-            $this->config->getBufferQueueNameFactory(),
+            $this->config->getJobQueueConfig()->getBufferQueueNameFactory(),
             $name,
             $params,
             $options
@@ -125,7 +125,7 @@ class QueueManager
     public function getWorkerQueueNameForJob($name, array $params, array $options)
     {
         return call_user_func(
-            $this->config->getWorkerQueueNameFactory(),
+            $this->config->getJobQueueConfig()->getWorkerQueueNameFactory(),
             $name,
             $params,
             $options

--- a/tests/src/Hodor/JobQueue/Config/JobQueueConfigTest.php
+++ b/tests/src/Hodor/JobQueue/Config/JobQueueConfigTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Hodor\JobQueue\Config;
+
+use Exception;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @coversDefaultClass Hodor\JobQueue\Config\JobQueueConfig
+ */
+class JobQueueConfigTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::getJobRunnerFactory
+     * @expectedException Exception
+     */
+    public function testAJobRunnerFactoryMustBeConfigured()
+    {
+        $config = new JobQueueConfig([]);
+
+        $config->getJobRunnerFactory();
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getJobRunnerFactory
+     * @expectedException Exception
+     */
+    public function testTheJobRunnerFactoryMustBeACallable()
+    {
+        $config = new JobQueueConfig([
+            'job_runner' => 'blah',
+        ]);
+
+        $config->getJobRunnerFactory();
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getJobRunnerFactory
+     * @dataProvider configProvider
+     */
+    public function testTheJobRunnerFactoryIsReturnedIfProperlyConfigured($options)
+    {
+        $config = new JobQueueConfig($options);
+
+        $callback = $config->getJobRunnerFactory();
+
+        $this->assertTrue(is_callable($callback));
+        $this->assertSame(
+            $options['job_runner'],
+            $callback
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getWorkerQueueNameFactory
+     * @expectedException \Exception
+     */
+    public function testWorkerQueueNameFactoryThrowsExceptionIfItIsNotCallable()
+    {
+        $config = new JobQueueConfig([
+            'worker_queue_name_factory' => 'blah',
+        ]);
+
+        $config->getWorkerQueueNameFactory();
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getWorkerQueueNameFactory
+     * @dataProvider configProvider
+     */
+    public function testWorkerQueueNameFactoryIsDefaultedToQueueNameOptionsCallback($options)
+    {
+        unset($options['worker_queue_name_factory']);
+        $config = new JobQueueConfig($options);
+
+        $callback = $config->getWorkerQueueNameFactory();
+
+        $this->assertTrue(is_callable($callback));
+        $this->assertEquals(
+            'default',
+            call_user_func($callback, 'n/a', [], ['queue_name' => 'default'])
+        );
+        $this->assertEquals(
+            'other',
+            call_user_func($callback, 'n/a', [], ['queue_name' => 'other'])
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getWorkerQueueNameFactory
+     * @dataProvider configProvider
+     * @expectedException \Exception
+     */
+    public function testDefaultWorkerQueueNameThrowsAnExceptionIfQueueNameIsNotProvided($options)
+    {
+        unset($options['worker_queue_name_factory']);
+        $config = new JobQueueConfig($options);
+
+        $callback = $config->getWorkerQueueNameFactory();
+
+        $this->assertTrue(is_callable($callback));
+        $this->assertEquals(
+            'other',
+            call_user_func($callback, 'n/a', [], ['not_queue_name' => 'other'])
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getWorkerQueueNameFactory
+     * @dataProvider configProvider
+     */
+    public function testWorkerQueueNameFactoryCanBeProvided($options)
+    {
+        $config = new JobQueueConfig($options);
+
+        $callback = $config->getWorkerQueueNameFactory();
+
+        $this->assertTrue(is_callable($callback));
+        $this->assertEquals(
+            'non-default',
+            call_user_func($callback, 'non-default', [], ['queue_name' => 'default'])
+        );
+        $this->assertEquals(
+            'another',
+            call_user_func($callback, 'another', [], ['queue_name' => 'other'])
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getBufferQueueNameFactory
+     * @expectedException \Exception
+     */
+    public function testBufferQueueNameFactoryThrowsExceptionIfItIsNotCallable()
+    {
+        $config = new JobQueueConfig([
+            'buffer_queue_name_factory' => 'blah',
+        ]);
+
+        $config->getBufferQueueNameFactory();
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getBufferQueueNameFactory
+     * @dataProvider configProvider
+     */
+    public function testBufferQueueNameFactoryIsDefaultedToDefaultQueue($options)
+    {
+        unset($options['buffer_queue_name_factory']);
+        $config = new JobQueueConfig($options);
+
+        $callback = $config->getBufferQueueNameFactory();
+
+        $this->assertTrue(is_callable($callback));
+        $this->assertEquals(
+            'default',
+            call_user_func($callback, 'n/a', [], ['queue_name' => 'default'])
+        );
+        $this->assertEquals(
+            'default',
+            call_user_func($callback, 'n/a', [], ['queue_name' => 'other'])
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getBufferQueueNameFactory
+     * @dataProvider configProvider
+     */
+    public function testBufferQueueNameFactoryCanBeProvided($options)
+    {
+        $config = new JobQueueConfig($options);
+
+        $callback = $config->getBufferQueueNameFactory();
+
+        $this->assertTrue(is_callable($callback));
+        $this->assertEquals(
+            'non-default',
+            call_user_func($callback, 'non-default', [], ['queue_name' => 'default'])
+        );
+        $this->assertEquals(
+            'another',
+            call_user_func($callback, 'another', [], ['queue_name' => 'other'])
+        );
+    }
+
+    public function configProvider()
+    {
+        return [
+            [[
+                'worker_queue_name_factory' => function($name, $params, $options) {
+                    return $name;
+                },
+                'buffer_queue_name_factory' => function($name, $params, $options) {
+                    return $name;
+                },
+                'job_runner' => function($name, $params) {
+                    return [$name, $params];
+                },
+            ]],
+        ];
+    }
+}


### PR DESCRIPTION
The JobQueue\Config class has gotten large and I
want to split its functionality into smaller pieces
