### PR TITLE
Abstract MQ config implementation out of JQ config

### DIFF
--- a/src/Hodor/JobQueue/Config/MessageQueueConfig.php
+++ b/src/Hodor/JobQueue/Config/MessageQueueConfig.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Hodor\JobQueue\Config;
+
+use Exception;
+use Hodor\MessageQueue\Adapter\Amqp\Factory as AmqpFactory;
+use Hodor\MessageQueue\Adapter\ConfigInterface;
+use Hodor\MessageQueue\Adapter\FactoryInterface;
+use Hodor\MessageQueue\Adapter\Testing\Factory as TestingFactory;
+
+class MessageQueueConfig implements ConfigInterface
+{
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @var FactoryInterface
+     */
+    private $adapter_factory;
+
+    /**
+     * @var array
+     */
+    private $queue_configs;
+
+    public function __construct($config)
+    {
+        $this->config = array_merge(
+            [
+                'adapter_factory'       => null,
+                'queue_defaults'        => [],
+                'worker_queues'         => [],
+                'worker_queue_defaults' => [],
+                'workers_per_server'    => null,
+                'buffer_queues'         => [],
+                'buffer_queue_defaults' => [],
+                'bufferers_per_server'  => null,
+            ],
+            $config
+        );
+    }
+
+    /**
+     * @return FactoryInterface
+     */
+    public function getAdapterFactory()
+    {
+        if ($this->adapter_factory) {
+            return $this->adapter_factory;
+        }
+
+        $this->adapter_factory = $this->generateAdapterFactory();
+
+        return $this->adapter_factory;
+    }
+
+    /**
+     * @param  string $queue_name
+     * @return array
+     * @throws Exception
+     */
+    public function getQueueConfig($queue_name)
+    {
+        if (!$this->queue_configs) {
+            $this->initQueues();
+        }
+
+        if (!isset($this->queue_configs[$queue_name])) {
+            throw new Exception(
+                "Queue name '{$queue_name}' not found in queues config."
+            );
+        }
+
+        return $this->queue_configs[$queue_name];
+    }
+
+    /**
+     * @return FactoryInterface
+     */
+    private function generateAdapterFactory()
+    {
+        if ('testing' === $this->config['adapter_factory']) {
+            return new TestingFactory($this);
+        }
+
+        return new AmqpFactory($this);
+    }
+
+    /**
+     * @return array
+     */
+    private function initQueues()
+    {
+        $this->initQueuesForType(
+            'worker',
+            'worker_queues',
+            'worker_queue_defaults',
+            'workers_per_server'
+        );
+        $this->initQueuesForType(
+            'bufferer',
+            'buffer_queues',
+            'buffer_queue_defaults',
+            'bufferers_per_server'
+        );
+    }
+
+    /**
+     * @param string $type
+     * @param string $queue_key
+     * @param string $defaults_key
+     * @param string $process_count_key
+     */
+    private function initQueuesForType($type, $queue_key, $defaults_key, $process_count_key)
+    {
+        $queues = $this->config[$queue_key];
+
+        $defaults = array_merge(
+            [
+                'host'         => null,
+                'port'         => 5672,
+                'username'     => null,
+                'password'     => null,
+                'queue_prefix' => 'hodor-',
+            ],
+            $this->config['queue_defaults'],
+            $this->config[$defaults_key]
+        );
+
+        foreach ($queues as $queue_name => $queue) {
+            $queue_config = array_merge($defaults, $queue);
+            $queue_config['queue_name'] = "{$queue_config['queue_prefix']}{$queue_name}";
+            $queue_config['key_name'] = $queue_name;
+            $queue_config['fetch_count'] = 1;
+            $queue_config['queue_type'] = $type;
+            $queue_config['process_count'] = $queue_config[$process_count_key];
+
+            $this->queue_configs["{$type}-{$queue_name}"] = $queue_config;
+        }
+    }
+}

--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -196,7 +196,7 @@ class QueueManager
             return $this->mq_factory;
         }
 
-        $this->mq_factory = new MqFactory($this->config);
+        $this->mq_factory = new MqFactory($this->config->getMessageQueueConfig());
 
         return $this->mq_factory;
     }

--- a/tests/src/Hodor/JobQueue/BufferQueueTest.php
+++ b/tests/src/Hodor/JobQueue/BufferQueueTest.php
@@ -4,6 +4,7 @@ namespace Hodor\JobQueue;
 
 use DateTime;
 use Exception;
+use Hodor\JobQueue\Config\MessageQueueConfig;
 use Hodor\MessageQueue\Adapter\ConsumerInterface;
 use Hodor\MessageQueue\Adapter\ProducerInterface;
 use Hodor\MessageQueue\IncomingMessage;
@@ -52,8 +53,9 @@ class BufferQueueTest extends PHPUnit_Framework_TestCase
                 ],
             ],
         ]);
-        $this->consumer = $this->config->getAdapterFactory()->getConsumer('bufferer-default');
-        $this->producer = $this->config->getAdapterFactory()->getProducer('bufferer-default');
+        $mq_config = $this->config->getMessageQueueConfig();
+        $this->consumer = $mq_config->getAdapterFactory()->getConsumer('bufferer-default');
+        $this->producer = $mq_config->getAdapterFactory()->getProducer('bufferer-default');
         $this->queue = new Queue($this->consumer, $this->producer);
         $this->queue_manager = new QueueManager($this->config);
     }

--- a/tests/src/Hodor/JobQueue/Config/MessageQueueConfigTest.php
+++ b/tests/src/Hodor/JobQueue/Config/MessageQueueConfigTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Hodor\JobQueue\Config;
+
+use Exception;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @coversDefaultClass Hodor\JobQueue\Config\MessageQueueConfig
+ */
+class MessageQueueConfigTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::getQueueConfig
+     * @covers ::<private>
+     * @dataProvider provideQueueConfigs
+     * @param array $expected_config
+     * @param $queue_name
+     * @param array $hodor_config
+     * @throws Exception
+     */
+    public function testQueueConfigCanBeGenerated(array $expected_config, $queue_name, array $hodor_config)
+    {
+        $config = new MessageQueueConfig($hodor_config);
+
+        $this->assertEquals($expected_config, $config->getQueueConfig($queue_name));
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getQueueConfig
+     * @covers ::<private>
+     * @expectedException Exception
+     */
+    public function testQueueConfigForUnknownConfigThrowsAnException()
+    {
+        $config = new MessageQueueConfig(['worker_queues' => []]);
+        $config->getQueueConfig('worker-missing');
+    }
+
+    /**
+     * @covers ::generateAdapterFactory
+     * @covers ::getAdapterFactory
+     * @covers ::<private>
+     */
+    public function testAdapterFactoryCanBeRetrieved()
+    {
+        $this->assertInstanceOf(
+            'Hodor\MessageQueue\Adapter\Amqp\Factory',
+            (new MessageQueueConfig([]))->getAdapterFactory()
+        );
+    }
+
+    /**
+     * @covers ::generateAdapterFactory
+     * @covers ::getAdapterFactory
+     * @covers ::<private>
+     */
+    public function testAdapterFactoryIsReused()
+    {
+        $config = new MessageQueueConfig([]);
+
+        $this->assertSame(
+            $config->getAdapterFactory(),
+            $config->getAdapterFactory()
+        );
+    }
+
+    /**
+     * @covers ::generateAdapterFactory
+     * @covers ::getAdapterFactory
+     * @covers ::<private>
+     */
+    public function testTestingAdapterFactoryCanBeRetrieved()
+    {
+        $this->assertInstanceOf(
+            'Hodor\MessageQueue\Adapter\Testing\Factory',
+            (new MessageQueueConfig(['adapter_factory' => 'testing']))->getAdapterFactory()
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function provideQueueConfigs()
+    {
+        return require __DIR__ . '/../ConfigTest.queue-config.dataset.php';
+    }
+}

--- a/tests/src/Hodor/JobQueue/JobQueueTest.php
+++ b/tests/src/Hodor/JobQueue/JobQueueTest.php
@@ -92,7 +92,7 @@ class JobQueueTest extends PHPUnit_Framework_TestCase
         $expected_job = $this->queueJob();
 
         try {
-            $consumer = $config->getAdapterFactory()->getConsumer('bufferer-default');
+            $consumer = $config->getMessageQueueConfig()->getAdapterFactory()->getConsumer('bufferer-default');
             $consumer->consumeMessage(function () {
                 $this->fail('A message should not be available for consuming until after batch is published.');
             });
@@ -171,7 +171,7 @@ class JobQueueTest extends PHPUnit_Framework_TestCase
      */
     private function assertBufferedJobEquals(array $expected_job, Config $config)
     {
-        $consumer = $config->getAdapterFactory()->getConsumer('bufferer-default');
+        $consumer = $config->getMessageQueueConfig()->getAdapterFactory()->getConsumer('bufferer-default');
         $consumer->consumeMessage(function (IncomingMessage $message) use ($expected_job) {
             $received_job = $message->getContent();
             $this->assertEquals($expected_job, [


### PR DESCRIPTION
Move JobQueue\Config's `getQueueConfig()` and `getAdapterFactory()`
methods to a separate class so that the new class can be responsible
for one thing: configuring the message queue.
