### PR TITLE
Remove unused config options from MQConfig

### DIFF
--- a/src/Hodor/JobQueue/Config.php
+++ b/src/Hodor/JobQueue/Config.php
@@ -75,10 +75,8 @@ class Config
             'queue_defaults'        => $this->getOption('queue_defaults', []),
             'worker_queues'         => $this->getOption('worker_queues', []),
             'worker_queue_defaults' => $this->getOption('worker_queue_defaults', []),
-            'workers_per_server'    => $this->getOption('workers_per_server'),
             'buffer_queues'         => $this->getOption('buffer_queues', []),
             'buffer_queue_defaults' => $this->getOption('buffer_queue_defaults', []),
-            'bufferers_per_server'  => $this->getOption('bufferers_per_server'),
         ]);
 
         return $this->message_queue_config;

--- a/src/Hodor/JobQueue/Config/MessageQueueConfig.php
+++ b/src/Hodor/JobQueue/Config/MessageQueueConfig.php
@@ -33,10 +33,8 @@ class MessageQueueConfig implements ConfigInterface
                 'queue_defaults'        => [],
                 'worker_queues'         => [],
                 'worker_queue_defaults' => [],
-                'workers_per_server'    => null,
                 'buffer_queues'         => [],
                 'buffer_queue_defaults' => [],
-                'bufferers_per_server'  => null,
             ],
             $config
         );


### PR DESCRIPTION
The options were incorrectly added to the list of
config options when splitting the MQConfig out of the
monolithic JobQueue\Config class
