### PR TITLE
Rename queue_type and key_name

### DIFF
--- a/src/Hodor/Daemon/SupervisordManager.php
+++ b/src/Hodor/Daemon/SupervisordManager.php
@@ -78,8 +78,8 @@ class SupervisordManager implements ManagerInterface
             '-c ' . escapeshellarg($this->config->getConfigPath()),
         ];
 
-        if ('superqueuer' !== $program_config['queue_type']) {
-            $command_pieces[] = '-q ' . escapeshellarg($program_config['key_name']);
+        if ('superqueuer' !== $program_config['worker_type']) {
+            $command_pieces[] = '-q ' . escapeshellarg($program_config['worker_name']);
         }
 
         return implode(" ", $command_pieces);
@@ -102,13 +102,13 @@ class SupervisordManager implements ManagerInterface
     {
         $search = [
             '{{PROGRAM_PREFIX}}',
-            '{{QUEUE_TYPE}}',
-            '{{QUEUE_NAME}}',
+            '{{WORKER_TYPE}}',
+            '{{WORKER_NAME}}',
         ];
         $replace = [
             $program_config['program_prefix'],
-            $program_config['queue_type'],
-            $program_config['key_name'],
+            $program_config['worker_type'],
+            $program_config['worker_name'],
         ];
 
         $program_config['program_name'] = str_replace(
@@ -127,7 +127,7 @@ class SupervisordManager implements ManagerInterface
             'config_path'    => '/etc/supervisord/conf.d/hodor.conf',
             'process_owner'  => 'apache',
             'program_prefix' => 'hodor',
-            'program_name' => '{{PROGRAM_PREFIX}}-{{QUEUE_TYPE}}-{{QUEUE_NAME}}',
+            'program_name' => '{{PROGRAM_PREFIX}}-{{WORKER_TYPE}}-{{WORKER_NAME}}',
             'logs'           => [
                 'error' => [
                     'path'         => '/var/log/hodor/%(program_name)s_%(process_num)d.error.log',

--- a/src/Hodor/JobQueue/Config/QueueConfig.php
+++ b/src/Hodor/JobQueue/Config/QueueConfig.php
@@ -71,8 +71,8 @@ class QueueConfig
         $queue_config = $this->getQueueConfig($queue_name);
 
         return [
-            'queue_type'    => $queue_config['queue_type'],
-            'key_name'      => $queue_config['key_name'],
+            'worker_type'   => $queue_config['worker_type'],
+            'worker_name'   => $queue_config['worker_name'],
             'process_count' => $queue_config['process_count'],
         ];
     }
@@ -131,8 +131,8 @@ class QueueConfig
 
         $this->queue_configs = [];
         $this->queue_configs['superqueuer-default'] = [
-            'queue_type'    => 'superqueuer',
-            'key_name'   => 'default',
+            'worker_type'   => 'superqueuer',
+            'worker_name'   => 'default',
             'process_count' => 1,
         ];
 
@@ -180,9 +180,9 @@ class QueueConfig
         foreach ($queues as $queue_name => $queue) {
             $queue_config = array_merge($defaults, $queue);
             $queue_config['queue_name'] = "{$queue_config['queue_prefix']}{$queue_name}";
-            $queue_config['key_name'] = $queue_name;
+            $queue_config['worker_name'] = $queue_name;
             $queue_config['fetch_count'] = 1;
-            $queue_config['queue_type'] = $type;
+            $queue_config['worker_type'] = $type;
             $queue_config['process_count'] = $queue_config[$process_count_key];
 
             $this->queue_configs["{$type}-{$queue_name}"] = $queue_config;

--- a/src/Hodor/JobQueue/Config/WorkerConfig.php
+++ b/src/Hodor/JobQueue/Config/WorkerConfig.php
@@ -57,12 +57,12 @@ class WorkerConfig
         foreach ($this->queue_config->getQueueNames() as $queue_name) {
             $queue_config = $this->queue_config->getWorkerConfig($queue_name);
 
-            $key_name = "{$queue_config['queue_type']}-{$queue_config['key_name']}";
+            $key_name = "{$queue_config['worker_type']}-{$queue_config['worker_name']}";
             $this->worker_configs[$key_name] = [
-                'queue_type'    => $queue_config['queue_type'],
-                'key_name'      => $queue_config['key_name'],
+                'worker_type'   => $queue_config['worker_type'],
+                'worker_name'   => $queue_config['worker_name'],
                 'process_count' => $queue_config['process_count'],
-                'command'       => $this->getBinFilePath($this->worker_commands[$queue_config['queue_type']]),
+                'command'       => $this->getBinFilePath($this->worker_commands[$queue_config['worker_type']]),
             ];
         }
 

--- a/tests/src/Hodor/JobQueue/Config/QueueConfigTest.php
+++ b/tests/src/Hodor/JobQueue/Config/QueueConfigTest.php
@@ -65,8 +65,8 @@ class QueueConfigTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             [
-                'queue_type'    => $expected_config['queue_type'],
-                'key_name'      => $expected_config['key_name'],
+                'worker_type'   => $expected_config['worker_type'],
+                'worker_name'   => $expected_config['worker_name'],
                 'process_count' => $expected_config['process_count'],
             ],
             $config->getWorkerConfig($queue_name)

--- a/tests/src/Hodor/JobQueue/Config/WorkerConfigTest.php
+++ b/tests/src/Hodor/JobQueue/Config/WorkerConfigTest.php
@@ -67,20 +67,20 @@ class WorkerConfigTest extends PHPUnit_Framework_TestCase
         $this->assertSame(
             [
                 'superqueuer-default' => [
-                    'queue_type'    => 'superqueuer',
-                    'key_name'      => 'default',
+                    'worker_type'   => 'superqueuer',
+                    'worker_name'   => 'default',
                     'process_count' => 1,
                     'command'       => "{$base_path}/superqueuer.php",
                 ],
                 'bufferer-buffer-worker' => [
-                    'queue_type'    => 'bufferer',
-                    'key_name'      => 'buffer-worker',
+                    'worker_type'   => 'bufferer',
+                    'worker_name'   => 'buffer-worker',
                     'process_count' => 15,
                     'command'       => "{$base_path}/buffer-worker.php",
                 ],
                 'worker-job-worker' => [
-                    'queue_type'    => 'worker',
-                    'key_name'      => 'job-worker',
+                    'worker_type'   => 'worker',
+                    'worker_name'   => 'job-worker',
                     'process_count' => 5,
                     'command'       => "{$base_path}/job-worker.php",
                 ],

--- a/tests/src/Hodor/JobQueue/ConfigTest.php
+++ b/tests/src/Hodor/JobQueue/ConfigTest.php
@@ -203,20 +203,20 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             [
                 'superqueuer-default' => [
-                    'queue_type'    => 'superqueuer',
-                    'key_name'      => 'default',
+                    'worker_type'   => 'superqueuer',
+                    'worker_name'   => 'default',
                     'process_count' => 1,
                     'command'       => "{$base_path}/superqueuer.php",
                 ],
                 'bufferer-default' => [
-                    'queue_type'    => 'bufferer',
-                    'key_name'      => 'default',
+                    'worker_type'   => 'bufferer',
+                    'worker_name'   => 'default',
                     'process_count' => 5,
                     'command'       => "{$base_path}/buffer-worker.php",
                 ],
                 'worker-default' => [
-                    'queue_type'    => 'worker',
-                    'key_name'      => 'default',
+                    'worker_type'   => 'worker',
+                    'worker_name'   => 'default',
                     'process_count' => 5,
                     'command'       => "{$base_path}/job-worker.php",
                 ],

--- a/tests/src/Hodor/JobQueue/ConfigTest.queue-config.dataset.php
+++ b/tests/src/Hodor/JobQueue/ConfigTest.queue-config.dataset.php
@@ -1,6 +1,6 @@
 <?php
 
-$scenario_maker = function ($queue_type, $queue_key, $defaults_key, $process_count_key) {
+$scenario_maker = function ($worker_type, $queue_key, $defaults_key, $process_count_key) {
     return [
         [
             // expected queue config
@@ -10,13 +10,13 @@ $scenario_maker = function ($queue_type, $queue_key, $defaults_key, $process_cou
                 'username'           => null,
                 'password'           => null,
                 'queue_name'         => "hodor-minimal",
-                'key_name'           => "minimal",
+                'worker_name'        => "minimal",
                 'fetch_count'        => 1,
                 'process_count'      => 5,
-                'queue_type'         => $queue_type,
+                'worker_type'        => $worker_type,
             ],
             // queue name to test
-            "{$queue_type}-minimal",
+            "{$worker_type}-minimal",
             // config array passed to Config object
             [
                 'queue_defaults' => [$process_count_key   => 5],
@@ -34,13 +34,13 @@ $scenario_maker = function ($queue_type, $queue_key, $defaults_key, $process_cou
                 'username'           => 'hare',
                 'password'           => 'turtle',
                 'queue_name'         => "willis-test-queue-defaults",
-                'key_name'           => "test-queue-defaults",
+                'worker_name'        => "test-queue-defaults",
                 'fetch_count'        => 1,
                 'process_count'      => 10,
-                'queue_type'         => $queue_type,
+                'worker_type'        => $worker_type,
             ],
             // queue name to test
-            "{$queue_type}-test-queue-defaults",
+            "{$worker_type}-test-queue-defaults",
             // config array passed to Config object
             [
                 'queue_defaults' => [
@@ -65,13 +65,13 @@ $scenario_maker = function ($queue_type, $queue_key, $defaults_key, $process_cou
                 'username'           => 'hared',
                 'password'           => 'turtled',
                 'queue_name'         => "willis-hodor-test-worker-queue-defaults",
-                'key_name'           => "test-worker-queue-defaults",
+                'worker_name'        => "test-worker-queue-defaults",
                 'fetch_count'        => 1,
                 'process_count'      => 15,
-                'queue_type'         => $queue_type,
+                'worker_type'        => $worker_type,
             ],
             // queue name to test
-            "{$queue_type}-test-worker-queue-defaults",
+            "{$worker_type}-test-worker-queue-defaults",
             // config array passed to Config object
             [
                 'queue_defaults' => [
@@ -103,13 +103,13 @@ $scenario_maker = function ($queue_type, $queue_key, $defaults_key, $process_cou
                 'username'           => 'fast',
                 'password'           => 'slow',
                 'queue_name'         => "hold-the-door-test-worker-queue",
-                'key_name'           => "test-worker-queue",
+                'worker_name'        => "test-worker-queue",
                 'fetch_count'        => 1,
                 'process_count'      => 20,
-                'queue_type'         => $queue_type,
+                'worker_type'        => $worker_type,
             ],
             // queue name to test
-            "{$queue_type}-test-worker-queue",
+            "{$worker_type}-test-worker-queue",
             // config array passed to Config object
             [
                 'queue_defaults' => [
@@ -148,13 +148,13 @@ $scenario_maker = function ($queue_type, $queue_key, $defaults_key, $process_cou
                 'username'           => 'fast',
                 'password'           => 'slow',
                 'queue_name'         => "hold-the-door-defaults-are-optional",
-                'key_name'           => "defaults-are-optional",
+                'worker_name'        => "defaults-are-optional",
                 'fetch_count'        => 1,
                 'process_count'      => 20,
-                'queue_type'         => $queue_type,
+                'worker_type'        => $worker_type,
             ],
             // queue name to test
-            "{$queue_type}-defaults-are-optional",
+            "{$worker_type}-defaults-are-optional",
             // config array passed to Config object
             [
                 $queue_key => [


### PR DESCRIPTION
Rename queue_type to worker_type and key_name to worker_name.
- The different types of workers use queues, so 'worker type'
  is more accurate than 'queue type'
- The 'key_name' title used to describe a hash (array) key, but
  it really is just the name of the worker, and sometimes the
  worker type is combined with the worker name to get the actual
  hash key
