### PR TITLE
Optimize QueueConfig methods for use cases

### DIFF
--- a/tests/src/Hodor/JobQueue/Config/QueueConfigTest.php
+++ b/tests/src/Hodor/JobQueue/Config/QueueConfigTest.php
@@ -108,6 +108,21 @@ class QueueConfigTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::getQueueNames
+     * @covers ::<private>
+     */
+    public function testQueueNamesCanBeRetrievedMultipleTimes()
+    {
+        $config = $this->getSimpleQueueConfig();
+
+        $this->assertSame(
+            $config->getQueueNames(),
+            $config->getQueueNames()
+        );
+    }
+
+    /**
+     * @covers ::__construct
      * @covers ::hasWorkerConfig
      * @covers ::<private>
      */


### PR DESCRIPTION
The `hasWorkerConfig()` method was indirectly generating
full-on worker configs for every worker defined even though
the method is only basically used in JobOptionsValidator when
a job is being pushed to a single worker.
