### PR TITLE
Convert queue name factory getters into queue name getters

### DIFF
--- a/src/Hodor/JobQueue/Config/JobQueueConfig.php
+++ b/src/Hodor/JobQueue/Config/JobQueueConfig.php
@@ -46,10 +46,36 @@ class JobQueueConfig
     }
 
     /**
+     * @param string $name
+     * @param array $params
+     * @param array $options
+     * @return string
+     */
+    public function getWorkerQueueName($name, array $params, array $options)
+    {
+        $factory = $this->getWorkerQueueNameFactory();
+
+        return call_user_func($factory, $name, $params, $options);
+    }
+
+    /**
+     * @param string $name
+     * @param array $params
+     * @param array $options
+     * @return string
+     */
+    public function getBufferQueueName($name, array $params, array $options)
+    {
+        $factory = $this->getBufferQueueNameFactory();
+
+        return call_user_func($factory, $name, $params, $options);
+    }
+
+    /**
      * @return callable
      * @throws Exception
      */
-    public function getWorkerQueueNameFactory()
+    private function getWorkerQueueNameFactory()
     {
         $worker_qname_factory = $this->config['worker_queue_name_factory'];
 
@@ -77,7 +103,7 @@ class JobQueueConfig
      * @return callable
      * @throws Exception
      */
-    public function getBufferQueueNameFactory()
+    private function getBufferQueueNameFactory()
     {
         $buffer_qname_factory = $this->config['buffer_queue_name_factory'];
 

--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -88,8 +88,7 @@ class QueueManager
      */
     public function getBufferQueueForJob($name, array $params, array $options)
     {
-        $queue_name = call_user_func(
-            $this->config->getJobQueueConfig()->getBufferQueueNameFactory(),
+        $queue_name = $this->config->getJobQueueConfig()->getBufferQueueName(
             $name,
             $params,
             $options
@@ -124,8 +123,7 @@ class QueueManager
      */
     public function getWorkerQueueNameForJob($name, array $params, array $options)
     {
-        return call_user_func(
-            $this->config->getJobQueueConfig()->getWorkerQueueNameFactory(),
+        return $this->config->getJobQueueConfig()->getWorkerQueueName(
             $name,
             $params,
             $options

--- a/tests/src/Hodor/JobQueue/Config/JobQueueConfigTest.php
+++ b/tests/src/Hodor/JobQueue/Config/JobQueueConfigTest.php
@@ -56,7 +56,8 @@ class JobQueueConfigTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers ::__construct
-     * @covers ::getWorkerQueueNameFactory
+     * @covers ::getWorkerQueueName
+     * @covers ::<private>
      * @expectedException \Exception
      */
     public function testWorkerQueueNameFactoryThrowsExceptionIfItIsNotCallable()
@@ -65,12 +66,13 @@ class JobQueueConfigTest extends PHPUnit_Framework_TestCase
             'worker_queue_name_factory' => 'blah',
         ]);
 
-        $config->getWorkerQueueNameFactory();
+        $config->getWorkerQueueName('job-worker', [], []);
     }
 
     /**
      * @covers ::__construct
-     * @covers ::getWorkerQueueNameFactory
+     * @covers ::getWorkerQueueName
+     * @covers ::<private>
      * @dataProvider configProvider
      */
     public function testWorkerQueueNameFactoryIsDefaultedToQueueNameOptionsCallback($options)
@@ -78,22 +80,20 @@ class JobQueueConfigTest extends PHPUnit_Framework_TestCase
         unset($options['worker_queue_name_factory']);
         $config = new JobQueueConfig($options);
 
-        $callback = $config->getWorkerQueueNameFactory();
-
-        $this->assertTrue(is_callable($callback));
         $this->assertEquals(
             'default',
-            call_user_func($callback, 'n/a', [], ['queue_name' => 'default'])
+            $config->getWorkerQueueName('n/a', [], ['queue_name' => 'default'])
         );
         $this->assertEquals(
             'other',
-            call_user_func($callback, 'n/a', [], ['queue_name' => 'other'])
+            $config->getWorkerQueueName('n/a', [], ['queue_name' => 'other'])
         );
     }
 
     /**
      * @covers ::__construct
-     * @covers ::getWorkerQueueNameFactory
+     * @covers ::getWorkerQueueName
+     * @covers ::<private>
      * @dataProvider configProvider
      * @expectedException \Exception
      */
@@ -102,40 +102,36 @@ class JobQueueConfigTest extends PHPUnit_Framework_TestCase
         unset($options['worker_queue_name_factory']);
         $config = new JobQueueConfig($options);
 
-        $callback = $config->getWorkerQueueNameFactory();
-
-        $this->assertTrue(is_callable($callback));
         $this->assertEquals(
             'other',
-            call_user_func($callback, 'n/a', [], ['not_queue_name' => 'other'])
+            $config->getWorkerQueueName('n/a', [], ['not_queue_name' => 'other'])
         );
     }
 
     /**
      * @covers ::__construct
-     * @covers ::getWorkerQueueNameFactory
+     * @covers ::getWorkerQueueName
+     * @covers ::<private>
      * @dataProvider configProvider
      */
     public function testWorkerQueueNameFactoryCanBeProvided($options)
     {
         $config = new JobQueueConfig($options);
 
-        $callback = $config->getWorkerQueueNameFactory();
-
-        $this->assertTrue(is_callable($callback));
         $this->assertEquals(
             'non-default',
-            call_user_func($callback, 'non-default', [], ['queue_name' => 'default'])
+            $config->getWorkerQueueName('non-default', [], ['queue_name' => 'default'])
         );
         $this->assertEquals(
             'another',
-            call_user_func($callback, 'another', [], ['queue_name' => 'other'])
+            $config->getWorkerQueueName('another', [], ['queue_name' => 'other'])
         );
     }
 
     /**
      * @covers ::__construct
-     * @covers ::getBufferQueueNameFactory
+     * @covers ::getBufferQueueName
+     * @covers ::<private>
      * @expectedException \Exception
      */
     public function testBufferQueueNameFactoryThrowsExceptionIfItIsNotCallable()
@@ -144,12 +140,13 @@ class JobQueueConfigTest extends PHPUnit_Framework_TestCase
             'buffer_queue_name_factory' => 'blah',
         ]);
 
-        $config->getBufferQueueNameFactory();
+        $config->getBufferQueueName('buffer-worker', [], []);
     }
 
     /**
      * @covers ::__construct
-     * @covers ::getBufferQueueNameFactory
+     * @covers ::getBufferQueueName
+     * @covers ::<private>
      * @dataProvider configProvider
      */
     public function testBufferQueueNameFactoryIsDefaultedToDefaultQueue($options)
@@ -157,38 +154,33 @@ class JobQueueConfigTest extends PHPUnit_Framework_TestCase
         unset($options['buffer_queue_name_factory']);
         $config = new JobQueueConfig($options);
 
-        $callback = $config->getBufferQueueNameFactory();
-
-        $this->assertTrue(is_callable($callback));
         $this->assertEquals(
             'default',
-            call_user_func($callback, 'n/a', [], ['queue_name' => 'default'])
+            $config->getBufferQueueName('n/a', [], ['queue_name' => 'default'])
         );
         $this->assertEquals(
             'default',
-            call_user_func($callback, 'n/a', [], ['queue_name' => 'other'])
+            $config->getBufferQueueName('n/a', [], ['queue_name' => 'other'])
         );
     }
 
     /**
      * @covers ::__construct
-     * @covers ::getBufferQueueNameFactory
+     * @covers ::getBufferQueueName
+     * @covers ::<private>
      * @dataProvider configProvider
      */
     public function testBufferQueueNameFactoryCanBeProvided($options)
     {
         $config = new JobQueueConfig($options);
 
-        $callback = $config->getBufferQueueNameFactory();
-
-        $this->assertTrue(is_callable($callback));
         $this->assertEquals(
             'non-default',
-            call_user_func($callback, 'non-default', [], ['queue_name' => 'default'])
+            $config->getBufferQueueName('non-default', [], ['queue_name' => 'default'])
         );
         $this->assertEquals(
             'another',
-            call_user_func($callback, 'another', [], ['queue_name' => 'other'])
+            $config->getBufferQueueName('another', [], ['queue_name' => 'other'])
         );
     }
 

--- a/tests/src/Hodor/JobQueue/ConfigTest.php
+++ b/tests/src/Hodor/JobQueue/ConfigTest.php
@@ -106,11 +106,11 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $uniqid = uniqid();
         $this->assertSame(
             $uniqid,
-            call_user_func($job_queue_config->getBufferQueueNameFactory(), $uniqid, [], [])
+            $job_queue_config->getBufferQueueName($uniqid, [], [])
         );
         $this->assertSame(
             $uniqid,
-            call_user_func($job_queue_config->getWorkerQueueNameFactory(), $uniqid, [], [])
+            $job_queue_config->getWorkerQueueName($uniqid, [], [])
         );
         $this->assertSame(
             [$uniqid, ['value' => $uniqid]],


### PR DESCRIPTION
Rather than retrieving the queue name factory and then
having to call it, add getters that will call the factory and
return the queue name.
