### PR TITLE
Make JobOptions\Validator's dependency more specific

### DIFF
--- a/src/Hodor/JobQueue/JobOptions/Validator.php
+++ b/src/Hodor/JobQueue/JobOptions/Validator.php
@@ -4,14 +4,14 @@ namespace Hodor\JobQueue\JobOptions;
 
 use DateTime;
 use Exception;
-use Hodor\JobQueue\Config;
+use Hodor\JobQueue\Config\WorkerConfig;
 
 class Validator
 {
     /**
-     * @var Config
+     * @var WorkerConfig
      */
-    private $config;
+    private $worker_config;
 
     /**
      * @var array
@@ -24,11 +24,11 @@ class Validator
     ];
 
     /**
-     * @param Config $config
+     * @param WorkerConfig $worker_config
      */
-    public function __construct(Config $config)
+    public function __construct(WorkerConfig $worker_config)
     {
-        $this->config = $config;
+        $this->worker_config = $worker_config;
     }
 
     /**
@@ -68,7 +68,7 @@ class Validator
      */
     private function validateQueueName(array $options)
     {
-        if ($this->config->getWorkerConfig()->hasWorkerConfig("worker", $options['queue_name'])) {
+        if ($this->worker_config->hasWorkerConfig("worker", $options['queue_name'])) {
             return;
         }
 

--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -139,7 +139,7 @@ class QueueManager
             return $this->job_options_validator;
         }
 
-        $this->job_options_validator = new JobOptionsValidator($this->config);
+        $this->job_options_validator = new JobOptionsValidator($this->config->getWorkerConfig());
 
         return $this->job_options_validator;
     }

--- a/tests/src/Hodor/JobQueue/JobOptions/ValidatorTest.php
+++ b/tests/src/Hodor/JobQueue/JobOptions/ValidatorTest.php
@@ -5,6 +5,8 @@ namespace Hodor\JobQueue\JobOptions;
 use DateTime;
 use Exception;
 use Hodor\JobQueue\Config;
+use Hodor\JobQueue\Config\QueueConfig;
+use Hodor\JobQueue\Config\WorkerConfig;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -137,12 +139,12 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
     private function generateValidator(Config $config = null)
     {
         if (!$config) {
-            $config = new Config(__FILE__, [
+            $config = new WorkerConfig(new QueueConfig([
                 'worker_queues' => [
                     'queue_a' => ['workers_per_server' => 5],
                     'queue_b' => ['workers_per_server' => 5],
                 ]
-            ]);
+            ]));
         }
 
         return new Validator($config);


### PR DESCRIPTION
The validator does not need access to all of Config,
but only needs Config\WorkerConfig
