### PR TITLE
Split new DB adapter's tests into separate tests

### DIFF
--- a/tests/src/Hodor/Database/AbstractAdapterTest.php
+++ b/tests/src/Hodor/Database/AbstractAdapterTest.php
@@ -24,12 +24,6 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
      * @covers ::bufferJob
      * @covers ::getJobsToRunGenerator
      * @covers ::<private>
-     * @covers Hodor\Database\Adapter\Testing\BufferWorker::__construct
-     * @covers Hodor\Database\Adapter\Postgres\BufferWorker::__construct
-     * @covers Hodor\Database\Adapter\Testing\BufferWorker::bufferJob
-     * @covers Hodor\Database\Adapter\Postgres\BufferWorker::bufferJob
-     * @covers Hodor\Database\Adapter\Testing\BufferWorker::<private>
-     * @covers Hodor\Database\Adapter\Postgres\BufferWorker::<private>
      * @param array $buffered_jobs
      * @param array $expected_jobs
      * @dataProvider provideBufferJobsScenarios
@@ -46,14 +40,6 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
      * @covers ::markJobAsQueued
      * @covers ::getJobsToRunGenerator
      * @covers ::<private>
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::__construct
-     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::__construct
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::getJobsToRunGenerator
-     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::getJobsToRunGenerator
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::markJobAsQueued
-     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::markJobAsQueued
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::<private>
-     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::<private>
      * @param array $buffered_jobs
      * @param array $queued_jobs
      * @param array $expected_jobs
@@ -69,12 +55,6 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::markJobAsSuccessful
      * @covers ::<private>
-     * @covers Hodor\Database\Adapter\Testing\Dequeuer::__construct
-     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::__construct
-     * @covers Hodor\Database\Adapter\Testing\Dequeuer::markJobAsSuccessful
-     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::markJobAsSuccessful
-     * @covers Hodor\Database\Adapter\Testing\Dequeuer::<private>
-     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::<private>
      */
     public function testJobCanBeMarkedAsSuccessful()
     {
@@ -86,12 +66,6 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::markJobAsFailed
      * @covers ::<private>
-     * @covers Hodor\Database\Adapter\Testing\Dequeuer::__construct
-     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::__construct
-     * @covers Hodor\Database\Adapter\Testing\Dequeuer::markJobAsFailed
-     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::markJobAsFailed
-     * @covers Hodor\Database\Adapter\Testing\Dequeuer::<private>
-     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::<private>
      */
     public function testJobCanBeMarkedAsFailed()
     {
@@ -103,12 +77,6 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::markJobAsSuccessful
      * @covers ::<private>
-     * @covers Hodor\Database\Adapter\Testing\Dequeuer::__construct
-     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::__construct
-     * @covers Hodor\Database\Adapter\Testing\Dequeuer::markJobAsSuccessful
-     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::markJobAsSuccessful
-     * @covers Hodor\Database\Adapter\Testing\Dequeuer::<private>
-     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::<private>
      * @expectedException Hodor\Database\Exception\BufferedJobNotFoundException
      */
     public function testMarkingUnrecognizedJobAsSuccessfulTriggersAnException()
@@ -119,12 +87,6 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::markJobAsFailed
      * @covers ::<private>
-     * @covers Hodor\Database\Adapter\Testing\Dequeuer::__construct
-     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::__construct
-     * @covers Hodor\Database\Adapter\Testing\Dequeuer::markJobAsFailed
-     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::markJobAsFailed
-     * @covers Hodor\Database\Adapter\Testing\Dequeuer::<private>
-     * @covers Hodor\Database\Adapter\Postgres\Dequeuer::<private>
      * @expectedException Hodor\Database\Exception\BufferedJobNotFoundException
      */
     public function testMarkingUnrecognizedJobAsFailedTriggersAnException()
@@ -135,18 +97,6 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::beginTransaction
      * @covers ::commitTransaction
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::__construct
-     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::__construct
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::getJobsToRunGenerator
-     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::getJobsToRunGenerator
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::beginBatch
-     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::beginBatch
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::markJobAsQueued
-     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::markJobAsQueued
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::publishBatch
-     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::publishBatch
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::<private>
-     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::<private>
      * @covers Hodor\Database\PgsqlAdapter::queryMultiple
      * @covers Hodor\Database\PgsqlAdapter::beginTransaction
      * @covers Hodor\Database\PgsqlAdapter::commitTransaction
@@ -180,13 +130,6 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers ::requestAdvisoryLock
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::__construct
-     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::__construct
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::__destruct
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::requestAdvisoryLock
-     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::requestAdvisoryLock
-     * @covers Hodor\Database\Adapter\Testing\Superqueuer::<private>
-     * @covers Hodor\Database\Adapter\Postgres\Superqueuer::<private>
      */
     public function testAdvisoryLockCanBeAcquired()
     {

--- a/tests/src/Hodor/Database/Adapter/BufferWorkerTest.php
+++ b/tests/src/Hodor/Database/Adapter/BufferWorkerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Hodor\Database\Adapter;
+
+use Hodor\Database\Adapter\TestUtil\JobsToRunAsserter;
+use Hodor\Database\Adapter\TestUtil\ScenarioCreator;
+use Hodor\Database\AdapterInterface;
+use PHPUnit_Framework_TestCase;
+
+abstract class BufferWorkerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var JobsToRunAsserter
+     */
+    private $asserter;
+
+    /**
+     * @var ScenarioCreator
+     */
+    private $scenario_creator;
+
+    /**
+     * @var AdapterInterface
+     */
+    private $adapter;
+
+    public function setUp()
+    {
+        $this->asserter = new JobsToRunAsserter($this);
+        $this->scenario_creator = new ScenarioCreator();
+    }
+
+    public function tearDown()
+    {
+        $this->adapter = null;
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::bufferJob
+     * @covers ::<private>
+     * @param array $buffered_jobs
+     * @param array $expected_jobs
+     * @dataProvider provideBufferJobsScenarios
+     */
+    public function testJobsCanBeBuffered(array $buffered_jobs, array $expected_jobs)
+    {
+        $superqueuer = $this->getAdapter()->getAdapterFactory()->getSuperqueuer();
+
+        $scenario = $this->scenario_creator->createScenario($this->getAdapter(), $buffered_jobs, []);
+
+        $this->asserter->assertJobsToRun($superqueuer, $scenario['uniqid'], $expected_jobs);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideBufferJobsScenarios()
+    {
+        return require __DIR__ . '/../AbstractAdapter.buffer-jobs.dataset.php';
+    }
+
+    /**
+     * @return AdapterInterface
+     */
+    abstract protected function generateAdapter();
+
+    /**
+     * @return AdapterInterface
+     */
+    protected function getAdapter()
+    {
+        if ($this->adapter) {
+            return $this->adapter;
+        }
+
+        $this->adapter = $this->generateAdapter();
+
+        return $this->adapter;
+    }
+}

--- a/tests/src/Hodor/Database/Adapter/DequeuerTest.php
+++ b/tests/src/Hodor/Database/Adapter/DequeuerTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Hodor\Database\Adapter;
+
+use Hodor\Database\Adapter\TestUtil\JobsToRunAsserter;
+use Hodor\Database\Adapter\TestUtil\ScenarioCreator;
+use Hodor\Database\AdapterInterface;
+use PHPUnit_Framework_TestCase;
+use Traversable;
+
+abstract class DequeuerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var JobsToRunAsserter
+     */
+    private $asserter;
+
+    /**
+     * @var ScenarioCreator
+     */
+    private $scenario_creator;
+
+    /**
+     * @var AdapterInterface
+     */
+    private $adapter;
+
+    public function setUp()
+    {
+        $this->asserter = new JobsToRunAsserter($this);
+        $this->scenario_creator = new ScenarioCreator();
+    }
+
+    public function tearDown()
+    {
+        $this->adapter = null;
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::markJobAsSuccessful
+     * @covers ::<private>
+     */
+    public function testJobCanBeMarkedAsSuccessful()
+    {
+        $this->markJobsAsCompleted(function ($meta) {
+            $this->getAdapter()->getAdapterFactory()->getDequeuer()->markJobAsSuccessful($meta);
+        });
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::markJobAsFailed
+     * @covers ::<private>
+     */
+    public function testJobCanBeMarkedAsFailed()
+    {
+        $this->markJobsAsCompleted(function ($meta) {
+            $this->getAdapter()->getAdapterFactory()->getDequeuer()->markJobAsFailed($meta);
+        });
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::markJobAsSuccessful
+     * @covers ::<private>
+     * @expectedException Hodor\Database\Exception\BufferedJobNotFoundException
+     */
+    public function testMarkingUnrecognizedJobAsSuccessfulTriggersAnException()
+    {
+        $this->getAdapter()->getAdapterFactory()->getDequeuer()->markJobAsSuccessful([
+            'buffered_job_id' => -1,
+        ]);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::markJobAsFailed
+     * @covers ::<private>
+     * @expectedException Hodor\Database\Exception\BufferedJobNotFoundException
+     */
+    public function testMarkingUnrecognizedJobAsFailedTriggersAnException()
+    {
+        $this->getAdapter()->getAdapterFactory()->getDequeuer()->markJobAsFailed([
+            'buffered_job_id' => -1,
+        ]);
+    }
+
+    /**
+     * @return AdapterInterface
+     */
+    abstract protected function generateAdapter();
+
+    /**
+     * @return AdapterInterface
+     */
+    protected function getAdapter()
+    {
+        if ($this->adapter) {
+            return $this->adapter;
+        }
+
+        $this->adapter = $this->generateAdapter();
+
+        return $this->adapter;
+    }
+
+    /**
+     * @param callable $mark_job_completed
+     */
+    private function markJobsAsCompleted(callable $mark_job_completed)
+    {
+        $superqueuer = $this->getAdapter()->getAdapterFactory()->getSuperqueuer();
+
+        $scenario = $this->scenario_creator->createScenario($this->getAdapter(),  [
+            ['name' => 1, 'mutex_id' => 'a'],
+            ['name' => 2, 'mutex_id' => 'a'],
+        ], []);
+        $uniqid = $scenario['uniqid'];
+
+        $this->asserter->assertJobsToRun($superqueuer, $uniqid, ['1']);
+
+        $jobs_to_complete = $this->markJobsAsQueued($superqueuer->getJobsToRunGenerator());
+
+        $this->asserter->assertJobsToRun($superqueuer, $uniqid, []);
+
+        foreach ($jobs_to_complete as $job) {
+            call_user_func($mark_job_completed, [
+                'buffered_job_id'    => $job['buffered_job_id'],
+                'started_running_at' => date('c'),
+            ]);
+        }
+
+        $this->asserter->assertJobsToRun($superqueuer, $uniqid, ['2']);
+    }
+
+    /**
+     * @param array|Traversable $jobs
+     * @return array
+     */
+    private function markJobsAsQueued($jobs)
+    {
+        $jobs_queued = [];
+
+        foreach ($jobs as $job) {
+            $meta = $this->getAdapter()->getAdapterFactory()->getSuperqueuer()->markJobAsQueued($job);
+            $jobs_queued[] = $meta;
+        }
+
+        return $jobs_queued;
+    }
+}

--- a/tests/src/Hodor/Database/Adapter/Postgres/BufferWorkerTest.php
+++ b/tests/src/Hodor/Database/Adapter/Postgres/BufferWorkerTest.php
@@ -2,53 +2,19 @@
 
 namespace Hodor\Database\Adapter\Postgres;
 
-use Exception;
 use Hodor\Database\Adapter\BufferWorkerTest as BufferWorkerBaseTest;
-use Hodor\Database\PgsqlAdapter;
-use Hodor\Database\Phpmig\CommandWrapper;
-use Hodor\Database\Phpmig\Container;
-use Symfony\Component\Console\Output\NullOutput;
+use Hodor\Database\Adapter\TestUtil\PostgresProvisioner;
 
 /**
  * @coversDefaultClass Hodor\Database\Adapter\Postgres\BufferWorker
  */
 class BufferWorkerTest extends BufferWorkerBaseTest
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $phpmig_container = new Container();
-        $phpmig_container->addDefaultServices('no-config-file');
-        $phpmig_container['hodor.database'] = $this->getAdapter();
-
-        $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
-        $command_wrapper->rollbackMigrations();
-        $command_wrapper->runMigrations();
-    }
-
-    public function tearDown()
-    {
-        parent::tearDown();
-
-        // without forcing garbage collection, the DB connections
-        // are not guaranteed to be disconnected; force GC
-        gc_collect_cycles();
-    }
-
     /**
-     * @return PgsqlAdapter
-     * @throws Exception
+     * @return PostgresProvisioner
      */
-    protected function generateAdapter()
+    protected function generateProvisioner()
     {
-        $config_path = __DIR__ . '/../../../../../../config/config.test.php';
-        if (!file_exists($config_path)) {
-            throw new Exception("'{$config_path}' not found");
-        }
-
-        $config = require $config_path;
-
-        return new PgsqlAdapter($config['test']['db']['yo-pdo-pgsql']);
+        return new PostgresProvisioner();
     }
 }

--- a/tests/src/Hodor/Database/Adapter/Postgres/BufferWorkerTest.php
+++ b/tests/src/Hodor/Database/Adapter/Postgres/BufferWorkerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Hodor\Database\Adapter\Postgres;
+
+use Exception;
+use Hodor\Database\Adapter\BufferWorkerTest as BufferWorkerBaseTest;
+use Hodor\Database\PgsqlAdapter;
+use Hodor\Database\Phpmig\CommandWrapper;
+use Hodor\Database\Phpmig\Container;
+use Symfony\Component\Console\Output\NullOutput;
+
+/**
+ * @coversDefaultClass Hodor\Database\Adapter\Postgres\BufferWorker
+ */
+class BufferWorkerTest extends BufferWorkerBaseTest
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $phpmig_container = new Container();
+        $phpmig_container->addDefaultServices('no-config-file');
+        $phpmig_container['hodor.database'] = $this->getAdapter();
+
+        $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
+        $command_wrapper->rollbackMigrations();
+        $command_wrapper->runMigrations();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        // without forcing garbage collection, the DB connections
+        // are not guaranteed to be disconnected; force GC
+        gc_collect_cycles();
+    }
+
+    /**
+     * @return PgsqlAdapter
+     * @throws Exception
+     */
+    protected function generateAdapter()
+    {
+        $config_path = __DIR__ . '/../../../../../../config/config.test.php';
+        if (!file_exists($config_path)) {
+            throw new Exception("'{$config_path}' not found");
+        }
+
+        $config = require $config_path;
+
+        return new PgsqlAdapter($config['test']['db']['yo-pdo-pgsql']);
+    }
+}

--- a/tests/src/Hodor/Database/Adapter/Postgres/DequeuerTest.php
+++ b/tests/src/Hodor/Database/Adapter/Postgres/DequeuerTest.php
@@ -2,53 +2,19 @@
 
 namespace Hodor\Database\Adapter\Postgres;
 
-use Exception;
 use Hodor\Database\Adapter\DequeuerTest as DequeuerBaseTest;
-use Hodor\Database\PgsqlAdapter;
-use Hodor\Database\Phpmig\CommandWrapper;
-use Hodor\Database\Phpmig\Container;
-use Symfony\Component\Console\Output\NullOutput;
+use Hodor\Database\Adapter\TestUtil\PostgresProvisioner;
 
 /**
  * @coversDefaultClass Hodor\Database\Adapter\Postgres\Dequeuer
  */
 class DequeuerTest extends DequeuerBaseTest
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $phpmig_container = new Container();
-        $phpmig_container->addDefaultServices('no-config-file');
-        $phpmig_container['hodor.database'] = $this->getAdapter();
-
-        $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
-        $command_wrapper->rollbackMigrations();
-        $command_wrapper->runMigrations();
-    }
-
-    public function tearDown()
-    {
-        parent::tearDown();
-
-        // without forcing garbage collection, the DB connections
-        // are not guaranteed to be disconnected; force GC
-        gc_collect_cycles();
-    }
-
     /**
-     * @return PgsqlAdapter
-     * @throws Exception
+     * @return PostgresProvisioner
      */
-    protected function generateAdapter()
+    protected function generateProvisioner()
     {
-        $config_path = __DIR__ . '/../../../../../../config/config.test.php';
-        if (!file_exists($config_path)) {
-            throw new Exception("'{$config_path}' not found");
-        }
-
-        $config = require $config_path;
-
-        return new PgsqlAdapter($config['test']['db']['yo-pdo-pgsql']);
+        return new PostgresProvisioner();
     }
 }

--- a/tests/src/Hodor/Database/Adapter/Postgres/DequeuerTest.php
+++ b/tests/src/Hodor/Database/Adapter/Postgres/DequeuerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Hodor\Database\Adapter\Postgres;
+
+use Exception;
+use Hodor\Database\Adapter\DequeuerTest as DequeuerBaseTest;
+use Hodor\Database\PgsqlAdapter;
+use Hodor\Database\Phpmig\CommandWrapper;
+use Hodor\Database\Phpmig\Container;
+use Symfony\Component\Console\Output\NullOutput;
+
+/**
+ * @coversDefaultClass Hodor\Database\Adapter\Postgres\Dequeuer
+ */
+class DequeuerTest extends DequeuerBaseTest
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $phpmig_container = new Container();
+        $phpmig_container->addDefaultServices('no-config-file');
+        $phpmig_container['hodor.database'] = $this->getAdapter();
+
+        $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
+        $command_wrapper->rollbackMigrations();
+        $command_wrapper->runMigrations();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        // without forcing garbage collection, the DB connections
+        // are not guaranteed to be disconnected; force GC
+        gc_collect_cycles();
+    }
+
+    /**
+     * @return PgsqlAdapter
+     * @throws Exception
+     */
+    protected function generateAdapter()
+    {
+        $config_path = __DIR__ . '/../../../../../../config/config.test.php';
+        if (!file_exists($config_path)) {
+            throw new Exception("'{$config_path}' not found");
+        }
+
+        $config = require $config_path;
+
+        return new PgsqlAdapter($config['test']['db']['yo-pdo-pgsql']);
+    }
+}

--- a/tests/src/Hodor/Database/Adapter/Postgres/SuperqueuerTest.php
+++ b/tests/src/Hodor/Database/Adapter/Postgres/SuperqueuerTest.php
@@ -2,53 +2,19 @@
 
 namespace Hodor\Database\Adapter\Postgres;
 
-use Exception;
 use Hodor\Database\Adapter\SuperqueuerTest as SuperqueuerBaseTest;
-use Hodor\Database\PgsqlAdapter;
-use Hodor\Database\Phpmig\CommandWrapper;
-use Hodor\Database\Phpmig\Container;
-use Symfony\Component\Console\Output\NullOutput;
+use Hodor\Database\Adapter\TestUtil\PostgresProvisioner;
 
 /**
  * @coversDefaultClass Hodor\Database\Adapter\Postgres\Superqueuer
  */
 class SuperqueuerTest extends SuperqueuerBaseTest
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $phpmig_container = new Container();
-        $phpmig_container->addDefaultServices('no-config-file');
-        $phpmig_container['hodor.database'] = $this->getAdapter();
-
-        $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
-        $command_wrapper->rollbackMigrations();
-        $command_wrapper->runMigrations();
-    }
-
-    public function tearDown()
-    {
-        parent::tearDown();
-
-        // without forcing garbage collection, the DB connections
-        // are not guaranteed to be disconnected; force GC
-        gc_collect_cycles();
-    }
-
     /**
-     * @return PgsqlAdapter
-     * @throws Exception
+     * @return PostgresProvisioner
      */
-    protected function generateAdapter()
+    protected function generateProvisioner()
     {
-        $config_path = __DIR__ . '/../../../../../../config/config.test.php';
-        if (!file_exists($config_path)) {
-            throw new Exception("'{$config_path}' not found");
-        }
-
-        $config = require $config_path;
-
-        return new PgsqlAdapter($config['test']['db']['yo-pdo-pgsql']);
+        return new PostgresProvisioner();
     }
 }

--- a/tests/src/Hodor/Database/Adapter/Postgres/SuperqueuerTest.php
+++ b/tests/src/Hodor/Database/Adapter/Postgres/SuperqueuerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Hodor\Database\Adapter\Postgres;
+
+use Exception;
+use Hodor\Database\Adapter\SuperqueuerTest as SuperqueuerBaseTest;
+use Hodor\Database\PgsqlAdapter;
+use Hodor\Database\Phpmig\CommandWrapper;
+use Hodor\Database\Phpmig\Container;
+use Symfony\Component\Console\Output\NullOutput;
+
+/**
+ * @coversDefaultClass Hodor\Database\Adapter\Postgres\Superqueuer
+ */
+class SuperqueuerTest extends SuperqueuerBaseTest
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $phpmig_container = new Container();
+        $phpmig_container->addDefaultServices('no-config-file');
+        $phpmig_container['hodor.database'] = $this->getAdapter();
+
+        $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
+        $command_wrapper->rollbackMigrations();
+        $command_wrapper->runMigrations();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        // without forcing garbage collection, the DB connections
+        // are not guaranteed to be disconnected; force GC
+        gc_collect_cycles();
+    }
+
+    /**
+     * @return PgsqlAdapter
+     * @throws Exception
+     */
+    protected function generateAdapter()
+    {
+        $config_path = __DIR__ . '/../../../../../../config/config.test.php';
+        if (!file_exists($config_path)) {
+            throw new Exception("'{$config_path}' not found");
+        }
+
+        $config = require $config_path;
+
+        return new PgsqlAdapter($config['test']['db']['yo-pdo-pgsql']);
+    }
+}

--- a/tests/src/Hodor/Database/Adapter/SuperqueuerTest.php
+++ b/tests/src/Hodor/Database/Adapter/SuperqueuerTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Hodor\Database\Adapter;
+
+use Hodor\Database\Adapter\TestUtil\JobsToRunAsserter;
+use Hodor\Database\Adapter\TestUtil\ScenarioCreator;
+use Hodor\Database\AdapterInterface;
+use PHPUnit_Framework_TestCase;
+
+abstract class SuperqueuerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var JobsToRunAsserter
+     */
+    private $asserter;
+
+    /**
+     * @var ScenarioCreator
+     */
+    private $scenario_creator;
+
+    /**
+     * @var AdapterInterface
+     */
+    private $adapter;
+
+    public function setUp()
+    {
+        $this->asserter = new JobsToRunAsserter($this);
+        $this->scenario_creator = new ScenarioCreator();
+    }
+
+    public function tearDown()
+    {
+        $this->adapter = null;
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::markJobAsQueued
+     * @covers ::getJobsToRunGenerator
+     * @covers ::<private>
+     * @param array $buffered_jobs
+     * @param array $queued_jobs
+     * @param array $expected_jobs
+     * @dataProvider provideQueueJobsScenarios
+     */
+    public function testJobsCanBeQueued(array $buffered_jobs, array $queued_jobs, array $expected_jobs)
+    {
+        $superqueuer = $this->getAdapter()->getAdapterFactory()->getSuperqueuer();
+
+        $scenario = $this->scenario_creator->createScenario($this->getAdapter(), $buffered_jobs, $queued_jobs);
+
+        $this->asserter->assertJobsToRun($superqueuer, $scenario['uniqid'], $expected_jobs);
+    }
+
+    /**
+     * @covers ::beginBatch
+     * @covers ::publishBatch
+     * @covers ::getJobsToRunGenerator
+     */
+    public function testQueueingJobsCanBeBatched()
+    {
+        $scenario = $this->scenario_creator->createScenario($this->getAdapter(),  [
+            ['name' => 1, 'mutex_id' => 'a'],
+            ['name' => 2, 'mutex_id' => 'a'],
+        ], []);
+        $uniqid = $scenario['uniqid'];
+
+        $current_connection = $this->getAdapter()->getAdapterFactory()->getSuperqueuer();
+        $other_connection = $this->generateAdapter()->getAdapterFactory()->getSuperqueuer();
+
+        $current_connection->beginBatch();
+
+        $jobs_to_run = $this->asserter->assertJobsToRun($current_connection, $uniqid, ['1']);
+        $this->asserter->assertJobsToRun($other_connection, $uniqid, ['1']);
+
+        $this->markJobsAsQueued($jobs_to_run);
+
+        $this->asserter->assertJobsToRun($current_connection, $uniqid, []);
+        $this->asserter->assertJobsToRun($other_connection, $uniqid, ['1']);
+
+        $current_connection->publishBatch();
+
+        $this->asserter->assertJobsToRun($current_connection, $uniqid, []);
+        $this->asserter->assertJobsToRun($other_connection, $uniqid, []);
+    }
+
+    /**
+     * @covers ::requestAdvisoryLock
+     */
+    public function testAdvisoryLockCanBeAcquired()
+    {
+        $connections = [
+            $this->generateAdapter(),
+            $this->generateAdapter(),
+            $this->generateAdapter(),
+        ];
+
+        $this->assertTrue($connections[0]->requestAdvisoryLock('test', 'lock'));
+        $this->assertFalse($connections[1]->requestAdvisoryLock('test', 'lock'));
+
+        unset($connections[0]);
+
+        // without forcing garbage collection, the DB connections
+        // are not guaranteed to be disconnected; force GC
+        gc_collect_cycles();
+
+        $this->assertTrue($connections[2]->requestAdvisoryLock('test', 'lock'));
+    }
+
+    /**
+     * @return array
+     */
+    public function provideQueueJobsScenarios()
+    {
+        return require __DIR__ . '/../AbstractAdapter.queue-jobs.dataset.php';
+    }
+
+    /**
+     * @return AdapterInterface
+     */
+    abstract protected function generateAdapter();
+
+    /**
+     * @return AdapterInterface
+     */
+    protected function getAdapter()
+    {
+        if ($this->adapter) {
+            return $this->adapter;
+        }
+
+        $this->adapter = $this->generateAdapter();
+
+        return $this->adapter;
+    }
+
+    /**
+     * @param array|Traversable $jobs
+     * @return array
+     */
+    private function markJobsAsQueued($jobs)
+    {
+        $jobs_queued = [];
+
+        foreach ($jobs as $job) {
+            $meta = $this->getAdapter()->markJobAsQueued($job);
+            $jobs_queued[] = $meta;
+        }
+
+        return $jobs_queued;
+    }
+}

--- a/tests/src/Hodor/Database/Adapter/TestUtil/AbstractProvisioner.php
+++ b/tests/src/Hodor/Database/Adapter/TestUtil/AbstractProvisioner.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Hodor\Database\Adapter\TestUtil;
+
+use Exception;
+use Hodor\Database\AdapterInterface;
+use Hodor\Database\PgsqlAdapter;
+
+abstract class AbstractProvisioner
+{
+    /**
+     * @var AdapterInterface
+     */
+    private $adapter;
+
+    abstract public function setUp();
+
+    public function tearDown()
+    {
+        $this->adapter = null;
+    }
+
+    /**
+     * @return AdapterInterface
+     * @throws Exception
+     */
+    abstract public function generateAdapter();
+
+    /**
+     * @return AdapterInterface
+     */
+    public function getAdapter()
+    {
+        if ($this->adapter) {
+            return $this->adapter;
+        }
+
+        $this->adapter = $this->generateAdapter();
+
+        return $this->adapter;
+    }
+}

--- a/tests/src/Hodor/Database/Adapter/TestUtil/PostgresProvisioner.php
+++ b/tests/src/Hodor/Database/Adapter/TestUtil/PostgresProvisioner.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Hodor\Database\Adapter\TestUtil;
+
+use Exception;
+use Hodor\Database\PgsqlAdapter;
+use Hodor\Database\Phpmig\CommandWrapper;
+use Hodor\Database\Phpmig\Container;
+use Symfony\Component\Console\Output\NullOutput;
+
+class PostgresProvisioner extends AbstractProvisioner
+{
+    public function setUp()
+    {
+        $phpmig_container = new Container();
+        $phpmig_container->addDefaultServices('no-config-file');
+        $phpmig_container['hodor.database'] = $this->getAdapter();
+
+        $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
+        $command_wrapper->rollbackMigrations();
+        $command_wrapper->runMigrations();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        // without forcing garbage collection, the DB connections
+        // are not guaranteed to be disconnected; force GC
+        gc_collect_cycles();
+    }
+
+    /**
+     * @return PgsqlAdapter
+     * @throws Exception
+     */
+    public function generateAdapter()
+    {
+        $config_path = __DIR__ . '/../../../../../../config/config.test.php';
+        if (!file_exists($config_path)) {
+            throw new Exception("'{$config_path}' not found");
+        }
+
+        $config = require $config_path;
+
+        return new PgsqlAdapter($config['test']['db']['yo-pdo-pgsql']);
+    }
+}

--- a/tests/src/Hodor/Database/Adapter/TestUtil/TestingProvisioner.php
+++ b/tests/src/Hodor/Database/Adapter/TestUtil/TestingProvisioner.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Hodor\Database\Adapter\TestUtil;
+
+use Hodor\Database\Adapter\Testing\Database;
+use Hodor\Database\Adapter\Testing\Factory;
+use Hodor\Database\ConverterAdapter;
+
+class TestingProvisioner extends AbstractProvisioner
+{
+    /**
+     * @var Database
+     */
+    private $database;
+
+    /**
+     * @var int
+     */
+    private $connection_id = 0;
+
+    public function setUp()
+    {
+        $this->database = new Database();
+    }
+
+    /**
+     * @return ConverterAdapter
+     */
+    public function generateAdapter()
+    {
+        return new ConverterAdapter(new Factory($this->database, ++$this->connection_id));
+    }
+}

--- a/tests/src/Hodor/Database/Adapter/Testing/BufferWorkerTest.php
+++ b/tests/src/Hodor/Database/Adapter/Testing/BufferWorkerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Hodor\Database\Adapter\Testing;
+
+use Hodor\Database\Adapter\BufferWorkerTest as BufferWorkerBaseTest;
+use Hodor\Database\ConverterAdapter;
+
+/**
+ * @coversDefaultClass Hodor\Database\Adapter\Testing\BufferWorker
+ */
+class BufferWorkerTest extends BufferWorkerBaseTest
+{
+    /**
+     * @var Database
+     */
+    private $database;
+
+    /**
+     * @var int
+     */
+    private $connection_id = 0;
+
+    /**
+     * @return ConverterAdapter
+     */
+    protected function generateAdapter()
+    {
+        return new ConverterAdapter(new Factory($this->getDatabase(), ++$this->connection_id));
+    }
+
+    /**
+     * @return Database
+     */
+    private function getDatabase()
+    {
+        if ($this->database) {
+            return $this->database;
+        }
+
+        $this->database = new Database();
+
+        return $this->database;
+    }
+}

--- a/tests/src/Hodor/Database/Adapter/Testing/BufferWorkerTest.php
+++ b/tests/src/Hodor/Database/Adapter/Testing/BufferWorkerTest.php
@@ -3,7 +3,7 @@
 namespace Hodor\Database\Adapter\Testing;
 
 use Hodor\Database\Adapter\BufferWorkerTest as BufferWorkerBaseTest;
-use Hodor\Database\ConverterAdapter;
+use Hodor\Database\Adapter\TestUtil\TestingProvisioner;
 
 /**
  * @coversDefaultClass Hodor\Database\Adapter\Testing\BufferWorker
@@ -11,34 +11,10 @@ use Hodor\Database\ConverterAdapter;
 class BufferWorkerTest extends BufferWorkerBaseTest
 {
     /**
-     * @var Database
+     * @return TestingProvisioner
      */
-    private $database;
-
-    /**
-     * @var int
-     */
-    private $connection_id = 0;
-
-    /**
-     * @return ConverterAdapter
-     */
-    protected function generateAdapter()
+    protected function generateProvisioner()
     {
-        return new ConverterAdapter(new Factory($this->getDatabase(), ++$this->connection_id));
-    }
-
-    /**
-     * @return Database
-     */
-    private function getDatabase()
-    {
-        if ($this->database) {
-            return $this->database;
-        }
-
-        $this->database = new Database();
-
-        return $this->database;
+        return new TestingProvisioner();
     }
 }

--- a/tests/src/Hodor/Database/Adapter/Testing/DequeuerTest.php
+++ b/tests/src/Hodor/Database/Adapter/Testing/DequeuerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Hodor\Database\Adapter\Testing;
+
+use Hodor\Database\Adapter\DequeuerTest as DequeuerBaseTest;
+use Hodor\Database\ConverterAdapter;
+
+/**
+ * @coversDefaultClass Hodor\Database\Adapter\Testing\Dequeuer
+ */
+class DequeuerTest extends DequeuerBaseTest
+{
+    /**
+     * @var Database
+     */
+    private $database;
+
+    /**
+     * @var int
+     */
+    private $connection_id = 0;
+
+    /**
+     * @return ConverterAdapter
+     */
+    protected function generateAdapter()
+    {
+        return new ConverterAdapter(new Factory($this->getDatabase(), ++$this->connection_id));
+    }
+
+    /**
+     * @return Database
+     */
+    private function getDatabase()
+    {
+        if ($this->database) {
+            return $this->database;
+        }
+
+        $this->database = new Database();
+
+        return $this->database;
+    }
+}

--- a/tests/src/Hodor/Database/Adapter/Testing/DequeuerTest.php
+++ b/tests/src/Hodor/Database/Adapter/Testing/DequeuerTest.php
@@ -3,7 +3,7 @@
 namespace Hodor\Database\Adapter\Testing;
 
 use Hodor\Database\Adapter\DequeuerTest as DequeuerBaseTest;
-use Hodor\Database\ConverterAdapter;
+use Hodor\Database\Adapter\TestUtil\TestingProvisioner;
 
 /**
  * @coversDefaultClass Hodor\Database\Adapter\Testing\Dequeuer
@@ -11,34 +11,10 @@ use Hodor\Database\ConverterAdapter;
 class DequeuerTest extends DequeuerBaseTest
 {
     /**
-     * @var Database
+     * @return TestingProvisioner
      */
-    private $database;
-
-    /**
-     * @var int
-     */
-    private $connection_id = 0;
-
-    /**
-     * @return ConverterAdapter
-     */
-    protected function generateAdapter()
+    protected function generateProvisioner()
     {
-        return new ConverterAdapter(new Factory($this->getDatabase(), ++$this->connection_id));
-    }
-
-    /**
-     * @return Database
-     */
-    private function getDatabase()
-    {
-        if ($this->database) {
-            return $this->database;
-        }
-
-        $this->database = new Database();
-
-        return $this->database;
+        return new TestingProvisioner();
     }
 }

--- a/tests/src/Hodor/Database/Adapter/Testing/SuperqueuerTest.php
+++ b/tests/src/Hodor/Database/Adapter/Testing/SuperqueuerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Hodor\Database\Adapter\Testing;
+
+use Hodor\Database\Adapter\SuperqueuerTest as SuperqueuerBaseTest;
+use Hodor\Database\ConverterAdapter;
+
+/**
+ * @coversDefaultClass Hodor\Database\Adapter\Testing\Superqueuer
+ */
+class SuperqueuerTest extends SuperqueuerBaseTest
+{
+    /**
+     * @var Database
+     */
+    private $database;
+
+    /**
+     * @var int
+     */
+    private $connection_id = 0;
+
+    /**
+     * @covers ::__destruct
+     * @covers ::requestAdvisoryLock
+     */
+    public function testAdvisoryLockCanBeAcquired()
+    {
+        parent::testAdvisoryLockCanBeAcquired();
+    }
+
+    /**
+     * @return ConverterAdapter
+     */
+    protected function generateAdapter()
+    {
+        return new ConverterAdapter(new Factory($this->getDatabase(), ++$this->connection_id));
+    }
+
+    /**
+     * @return Database
+     */
+    private function getDatabase()
+    {
+        if ($this->database) {
+            return $this->database;
+        }
+
+        $this->database = new Database();
+
+        return $this->database;
+    }
+}

--- a/tests/src/Hodor/Database/Adapter/Testing/SuperqueuerTest.php
+++ b/tests/src/Hodor/Database/Adapter/Testing/SuperqueuerTest.php
@@ -3,23 +3,13 @@
 namespace Hodor\Database\Adapter\Testing;
 
 use Hodor\Database\Adapter\SuperqueuerTest as SuperqueuerBaseTest;
-use Hodor\Database\ConverterAdapter;
+use Hodor\Database\Adapter\TestUtil\TestingProvisioner;
 
 /**
  * @coversDefaultClass Hodor\Database\Adapter\Testing\Superqueuer
  */
 class SuperqueuerTest extends SuperqueuerBaseTest
 {
-    /**
-     * @var Database
-     */
-    private $database;
-
-    /**
-     * @var int
-     */
-    private $connection_id = 0;
-
     /**
      * @covers ::__destruct
      * @covers ::requestAdvisoryLock
@@ -30,24 +20,10 @@ class SuperqueuerTest extends SuperqueuerBaseTest
     }
 
     /**
-     * @return ConverterAdapter
+     * @return TestingProvisioner
      */
-    protected function generateAdapter()
+    protected function generateProvisioner()
     {
-        return new ConverterAdapter(new Factory($this->getDatabase(), ++$this->connection_id));
-    }
-
-    /**
-     * @return Database
-     */
-    private function getDatabase()
-    {
-        if ($this->database) {
-            return $this->database;
-        }
-
-        $this->database = new Database();
-
-        return $this->database;
+        return new TestingProvisioner();
     }
 }


### PR DESCRIPTION
This is one step towards eliminating the old DB adapters.
