### PR TITLE
Move Phpmig away from depending on PgsqlAdapter

### DIFF
--- a/migrations/postgres/20151022112749_CreateInitialSchema.php
+++ b/migrations/postgres/20151022112749_CreateInitialSchema.php
@@ -1,15 +1,15 @@
 <?php
 
-use Hodor\Database\AdapterInterface as DbAdapterInterface;
 use Hodor\Database\Phpmig\Migration;
+use Lstr\YoPdo\YoPdo;
 
 class CreateInitialSchema extends Migration
 {
     /**
-     * @param DbAdapterInterface $db
+     * @param YoPdo $yo_pdo
      * @return void
      */
-    protected function transactionalUp(DbAdapterInterface $db)
+    protected function transactionalUp(YoPdo $yo_pdo)
     {
         $sql = <<<SQL
 CREATE TABLE buffered_jobs
@@ -88,14 +88,14 @@ CREATE TABLE failed_jobs
 );
 SQL;
 
-        $db->queryMultiple($sql);
+        $yo_pdo->queryMultiple($sql);
     }
 
     /**
-     * @param DbAdapterInterface $db
+     * @param YoPdo $yo_pdo
      * @return void
      */
-    protected function transactionalDown(DbAdapterInterface $db)
+    protected function transactionalDown(YoPdo $yo_pdo)
     {
         $sql = <<<SQL
 DROP TABLE buffered_jobs;
@@ -104,6 +104,6 @@ DROP TABLE successful_jobs;
 DROP TABLE failed_jobs;
 SQL;
 
-        $db->queryMultiple($sql);
+        $yo_pdo->queryMultiple($sql);
     }
 }

--- a/migrations/postgres/20151228082041_AddMutexId.php
+++ b/migrations/postgres/20151228082041_AddMutexId.php
@@ -1,15 +1,15 @@
 <?php
 
-use Hodor\Database\AdapterInterface as DbAdapterInterface;
 use Hodor\Database\Phpmig\Migration;
+use Lstr\YoPdo\YoPdo;
 
 class AddMutexId extends Migration
 {
     /**
-     * @param DbAdapterInterface $db
+     * @param YoPdo $yo_pdo
      * @return void
      */
-    protected function transactionalUp(DbAdapterInterface $db)
+    protected function transactionalUp(YoPdo $yo_pdo)
     {
         $sql = <<<SQL
 ALTER TABLE buffered_jobs
@@ -43,14 +43,14 @@ ALTER TABLE failed_jobs
     ALTER COLUMN mutex_id SET NOT NULL;
 SQL;
 
-        $db->queryMultiple($sql);
+        $yo_pdo->queryMultiple($sql);
     }
 
     /**
-     * @param DbAdapterInterface $db
+     * @param YoPdo $yo_pdo
      * @return void
      */
-    protected function transactionalDown(DbAdapterInterface $db)
+    protected function transactionalDown(YoPdo $yo_pdo)
     {
         $sql = <<<SQL
 ALTER TABLE buffered_jobs
@@ -63,6 +63,6 @@ ALTER TABLE failed_jobs
     DROP COLUMN mutex_id;
 SQL;
 
-        $db->queryMultiple($sql);
+        $yo_pdo->queryMultiple($sql);
     }
 }

--- a/src/Hodor/Database/Adapter/Postgres/Factory.php
+++ b/src/Hodor/Database/Adapter/Postgres/Factory.php
@@ -5,6 +5,7 @@ namespace Hodor\Database\Adapter\Postgres;
 use Hodor\Database\Adapter\FactoryInterface;
 use Hodor\Database\Driver\YoPdoDriver;
 use Hodor\Database\PgsqlAdapter;
+use Hodor\Database\Phpmig\PgsqlPhpmigAdapter;
 use Lstr\YoPdo\YoPdo;
 
 class Factory implements FactoryInterface
@@ -89,6 +90,14 @@ class Factory implements FactoryInterface
         $this->dequeuer = new Dequeuer($this->getConnection());
 
         return $this->dequeuer;
+    }
+
+    /**
+     * @return YoPdo
+     */
+    public function getYoPdo()
+    {
+        return $this->getConnection()->getYoPdo();
     }
 
     /**

--- a/src/Hodor/Database/PgsqlAdapter.php
+++ b/src/Hodor/Database/PgsqlAdapter.php
@@ -3,65 +3,14 @@
 namespace Hodor\Database;
 
 use Hodor\Database\Adapter\Postgres\Factory;
-use Hodor\Database\Driver\YoPdoDriver;
-use Hodor\Database\Phpmig\PgsqlPhpmigAdapter;
 
 class PgsqlAdapter extends ConverterAdapter
 {
-    /**
-     * @var array
-     */
-    private $config;
-
-    /**
-     * @var Factory
-     */
-    private $postgres_factory;
-
-    /**
-     * @var YoPdoDriver
-     */
-    private $driver;
-
     /**
      * @param array $config
      */
     public function __construct(array $config)
     {
-        $this->config = $config;
-        $this->postgres_factory = new Factory($this, $config);
-
-        parent::__construct($this->postgres_factory);
-    }
-
-    /**
-     * @return PgsqlPhpmigAdapter
-     */
-    public function getPhpmigAdapter()
-    {
-        return new PgsqlPhpmigAdapter($this->getDriver());
-    }
-
-    /**
-     * @param string $sql
-     * @return void
-     */
-    public function queryMultiple($sql)
-    {
-        return $this->getDriver()->queryMultiple($sql);
-    }
-
-    /**
-     * @return YoPdoDriver
-     */
-    private function getDriver()
-    {
-        if ($this->driver) {
-            return $this->driver;
-        }
-
-        $this->driver = $this->postgres_factory->getYoPdoDriver();
-
-        return $this->driver;
+        parent::__construct(new Factory($this, $config));
     }
 }

--- a/src/Hodor/Database/Phpmig/Container.php
+++ b/src/Hodor/Database/Phpmig/Container.php
@@ -5,6 +5,8 @@ namespace Hodor\Database\Phpmig;
 use Exception;
 use Hodor\Config\LoaderFactory as ConfigFactory;
 use Hodor\Database\AdapterFactory as DbFactory;
+use Hodor\Database\PgsqlAdapter;
+use Lstr\YoPdo\YoPdo;
 use Pimple;
 
 class Container extends Pimple
@@ -46,7 +48,7 @@ class Container extends Pimple
                 $db_factory = $container['hodor.database.factory'];
                 $db_config = $container['hodor.database.config'];
 
-                return $db_factory->getAdapter($db_config);
+                return $db_factory->getAdapter($db_config)->getAdapterFactory()->getYoPdo();
             }
         );
 
@@ -54,7 +56,7 @@ class Container extends Pimple
             function (Pimple $container) {
                 $db_adapter = $container['hodor.database'];
 
-                return $db_adapter->getPhpmigAdapter();
+                return new PgsqlPhpmigAdapter($db_adapter);
             }
         );
 
@@ -69,6 +71,14 @@ class Container extends Pimple
                 return __DIR__ . '/MigrationTemplate.php';
             }
         );
+    }
+
+    /**
+     * @return YoPdo
+     */
+    public function getYoPdo()
+    {
+        return $this['hodor.database'];
     }
 
     /**

--- a/src/Hodor/Database/Phpmig/Migration.php
+++ b/src/Hodor/Database/Phpmig/Migration.php
@@ -2,7 +2,7 @@
 
 namespace Hodor\Database\Phpmig;
 
-use Hodor\Database\AdapterInterface as DbAdapterInterface;
+use Lstr\YoPdo\YoPdo;
 use Phpmig\Migration\Migration as PhpmigMigration;
 
 abstract class Migration extends PhpmigMigration
@@ -12,12 +12,15 @@ abstract class Migration extends PhpmigMigration
      */
     public function up()
     {
+        /**
+         * @var $container Container
+         */
         $container = $this->getContainer();
-        $db = $container['hodor.database'];
+        $yo_pdo = $container->getYoPdo();
 
-        $db->beginTransaction();
-        $this->transactionalUp($db);
-        $db->commitTransaction();
+        $yo_pdo->transaction()->begin('phpmig');
+        $this->transactionalUp($yo_pdo);
+        $yo_pdo->transaction()->accept('phpmig');
     }
 
     /**
@@ -26,20 +29,20 @@ abstract class Migration extends PhpmigMigration
     public function down()
     {
         $container = $this->getContainer();
-        $db = $container['hodor.database'];
+        $yo_pdo = $container['hodor.database'];
 
-        $db->beginTransaction();
-        $this->transactionalDown($db);
-        $db->commitTransaction();
+        $yo_pdo->transaction()->begin('phpmig');
+        $this->transactionalDown($yo_pdo);
+        $yo_pdo->transaction()->accept('phpmig');
     }
 
     /**
-     * @param DbAdapterInterface $db
+     * @param YoPdo $yo_pdo
      */
-    abstract protected function transactionalUp(DbAdapterInterface $db);
+    abstract protected function transactionalUp(YoPdo $yo_pdo);
 
     /**
-     * @param DbAdapterInterface $db
+     * @param YoPdo $yo_pdo
      */
-    abstract protected function transactionalDown(DbAdapterInterface $db);
+    abstract protected function transactionalDown(YoPdo $yo_pdo);
 }

--- a/src/Hodor/Database/Phpmig/MigrationTemplate.php
+++ b/src/Hodor/Database/Phpmig/MigrationTemplate.php
@@ -1,23 +1,23 @@
 <?= "<?php\n";?>
 
-use Hodor\Database\AdapterInterface as DbAdapterInterface;
 use Hodor\Database\Phpmig\Migration;
+use Lstr\YoPdo\YoPdo;
 
 class <?= $className ?> extends Migration
 {
     /**
-     * @param DbAdapterInterface $db
+     * @param YoPdo $yo_pdo
      * @return void
      */
-    protected function transactionalUp(DbAdapterInterface $db)
+    protected function transactionalUp(YoPdo $yo_pdo)
     {
     }
 
     /**
-     * @param DbAdapterInterface $db
+     * @param YoPdo $yo_pdo
      * @return void
      */
-    protected function transactionalDown(DbAdapterInterface $db)
+    protected function transactionalDown(YoPdo $yo_pdo)
     {
     }
 }

--- a/tests/src/Hodor/Database/AbstractAdapterTest.php
+++ b/tests/src/Hodor/Database/AbstractAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Hodor\Database;
 
+use Hodor\Database\Adapter\TestUtil\AbstractProvisioner;
 use Hodor\Database\Adapter\TestUtil\JobsToRunAsserter;
 use Hodor\Database\Adapter\TestUtil\ScenarioCreator;
 use PHPUnit_Framework_TestCase;
@@ -10,13 +11,18 @@ use Traversable;
 abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var AdapterInterface
+     * @var AbstractProvisioner
      */
-    private $adapter;
+    private $provisioner;
+
+    public function setUp()
+    {
+        $this->getProvisioner()->setUp();
+    }
 
     public function tearDown()
     {
-        $this->adapter = null;
+        $this->getProvisioner()->tearDown();
     }
 
     /**
@@ -165,22 +171,38 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @return AbstractProvisioner
+     */
+    abstract protected function generateProvisioner();
+
+    /**
+     * @return AbstractProvisioner
+     */
+    protected function getProvisioner()
+    {
+        if ($this->provisioner) {
+            return $this->provisioner;
+        }
+
+        $this->provisioner = $this->generateProvisioner();
+
+        return $this->provisioner;
+    }
+
+    /**
      * @return AdapterInterface
      */
-    abstract protected function generateAdapter();
+    protected function generateAdapter()
+    {
+        return $this->getProvisioner()->generateAdapter();
+    }
 
     /**
      * @return AdapterInterface
      */
     protected function getAdapter()
     {
-        if ($this->adapter) {
-            return $this->adapter;
-        }
-
-        $this->adapter = $this->generateAdapter();
-
-        return $this->adapter;
+        return $this->getProvisioner()->getAdapter();
     }
 
     /**

--- a/tests/src/Hodor/Database/AbstractAdapterTest.php
+++ b/tests/src/Hodor/Database/AbstractAdapterTest.php
@@ -97,9 +97,6 @@ abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::beginTransaction
      * @covers ::commitTransaction
-     * @covers Hodor\Database\PgsqlAdapter::queryMultiple
-     * @covers Hodor\Database\PgsqlAdapter::beginTransaction
-     * @covers Hodor\Database\PgsqlAdapter::commitTransaction
      */
     public function testQueueingJobsCanBeBatched()
     {

--- a/tests/src/Hodor/Database/Adapter/Postgres/FactoryTest.php
+++ b/tests/src/Hodor/Database/Adapter/Postgres/FactoryTest.php
@@ -23,7 +23,7 @@ class FactoryTest extends FactoryBaseTest
     {
         $phpmig_container = new Container();
         $phpmig_container->addDefaultServices('no-config-file');
-        $phpmig_container['hodor.database'] = $this->getTestFactory()->getPgsqlAdapter();
+        $phpmig_container['hodor.database'] = $this->getTestFactory()->getYoPdo();
 
         $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
         $command_wrapper->rollbackMigrations();

--- a/tests/src/Hodor/Database/Adapter/TestUtil/PostgresProvisioner.php
+++ b/tests/src/Hodor/Database/Adapter/TestUtil/PostgresProvisioner.php
@@ -14,7 +14,7 @@ class PostgresProvisioner extends AbstractProvisioner
     {
         $phpmig_container = new Container();
         $phpmig_container->addDefaultServices('no-config-file');
-        $phpmig_container['hodor.database'] = $this->getAdapter();
+        $phpmig_container['hodor.database'] = $this->getAdapter()->getAdapterFactory()->getYoPdo();
 
         $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
         $command_wrapper->rollbackMigrations();

--- a/tests/src/Hodor/Database/PgsqlAdapterTest.php
+++ b/tests/src/Hodor/Database/PgsqlAdapterTest.php
@@ -17,7 +17,7 @@ class PgsqlAdapterTest extends AbstractAdapterTest
     {
         $phpmig_container = new Container();
         $phpmig_container->addDefaultServices('no-config-file');
-        $phpmig_container['hodor.database'] = $this->getAdapter();
+        $phpmig_container['hodor.database'] = $this->getAdapter()->getAdapterFactory()->getYoPdo();
 
         $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
         $command_wrapper->rollbackMigrations();
@@ -31,17 +31,6 @@ class PgsqlAdapterTest extends AbstractAdapterTest
         // without forcing garbage collection, the DB connections
         // are not guaranteed to be disconnected; force GC
         gc_collect_cycles();
-    }
-
-    /**
-     * @covers ::getPhpmigAdapter
-     */
-    public function testPhpmigAdapterCanBeRetrieved()
-    {
-        $this->assertInstanceOf(
-            'Hodor\Database\Phpmig\PgsqlPhpmigAdapter',
-            $this->getAdapter()->getPhpmigAdapter()
-        );
     }
 
     /**

--- a/tests/src/Hodor/Database/PgsqlAdapterTest.php
+++ b/tests/src/Hodor/Database/PgsqlAdapterTest.php
@@ -2,50 +2,18 @@
 
 namespace Hodor\Database;
 
-use Exception;
-
-use Hodor\Database\Phpmig\CommandWrapper;
-use Hodor\Database\Phpmig\Container;
-use Symfony\Component\Console\Output\NullOutput;
+use Hodor\Database\Adapter\TestUtil\PostgresProvisioner;
 
 /**
  * @coversDefaultClass Hodor\Database\PgsqlAdapter
  */
 class PgsqlAdapterTest extends AbstractAdapterTest
 {
-    public function setUp()
-    {
-        $phpmig_container = new Container();
-        $phpmig_container->addDefaultServices('no-config-file');
-        $phpmig_container['hodor.database'] = $this->getAdapter()->getAdapterFactory()->getYoPdo();
-
-        $command_wrapper = new CommandWrapper($phpmig_container, new NullOutput());
-        $command_wrapper->rollbackMigrations();
-        $command_wrapper->runMigrations();
-    }
-
-    public function tearDown()
-    {
-        parent::tearDown();
-
-        // without forcing garbage collection, the DB connections
-        // are not guaranteed to be disconnected; force GC
-        gc_collect_cycles();
-    }
-
     /**
-     * @return PgsqlAdapter
-     * @throws Exception
+     * @return PostgresProvisioner
      */
-    protected function generateAdapter()
+    protected function generateProvisioner()
     {
-        $config_path = __DIR__ . '/../../../../config/config.test.php';
-        if (!file_exists($config_path)) {
-            throw new Exception("'{$config_path}' not found");
-        }
-
-        $config = require $config_path;
-
-        return new PgsqlAdapter($config['test']['db']['yo-pdo-pgsql']);
+        return new PostgresProvisioner();
     }
 }

--- a/tests/src/Hodor/Database/TestingAdapterTest.php
+++ b/tests/src/Hodor/Database/TestingAdapterTest.php
@@ -2,10 +2,9 @@
 
 namespace Hodor\Database;
 
-use Exception;
-
 use Hodor\Database\Adapter\Testing\Database;
 use Hodor\Database\Adapter\Testing\Factory;
+use Hodor\Database\Adapter\TestUtil\TestingProvisioner;
 
 /**
  * @coversDefaultClass Hodor\Database\ConverterAdapter
@@ -13,37 +12,21 @@ use Hodor\Database\Adapter\Testing\Factory;
 class TestingAdapterTest extends AbstractAdapterTest
 {
     /**
-     * @var Database
-     */
-    private $database;
-
-    /**
-     * @var int
-     */
-    private $connection_id = 0;
-
-    public function setUp()
-    {
-        $this->database = new Database();
-    }
-
-    /**
      * @covers ::getAdapterFactory
      */
     public function testFactoryInterfaceIsSameInterfacePassedToConstructor()
     {
-        $factory = new Factory($this->database, ++$this->connection_id);
+        $factory = new Factory(new Database(), 1);
         $adapter = new ConverterAdapter($factory);
 
         $this->assertSame($factory, $adapter->getAdapterFactory());
     }
 
     /**
-     * @return ConverterAdapter
-     * @throws Exception
+     * @return PostgresProvisioner
      */
-    protected function generateAdapter()
+    protected function generateProvisioner()
     {
-        return new ConverterAdapter(new Factory($this->database, ++$this->connection_id));
+        return new TestingProvisioner();
     }
 }


### PR DESCRIPTION
Phpmig still depends on PgsqlAdapter to get the newer DB
adapter factory, but this will make it easier to swap out
the PgsqlAdapter for the new DB adapter factory across the
entire codebase.
