### PR TITLE
Call newer superqueuer DB adapter directly

### DIFF
--- a/tests/src/Hodor/Database/Adapter/SuperqueuerTest.php
+++ b/tests/src/Hodor/Database/Adapter/SuperqueuerTest.php
@@ -98,9 +98,9 @@ abstract class SuperqueuerTest extends PHPUnit_Framework_TestCase
     public function testAdvisoryLockCanBeAcquired()
     {
         $connections = [
-            $this->getProvisioner()->generateAdapter(),
-            $this->getProvisioner()->generateAdapter(),
-            $this->getProvisioner()->generateAdapter(),
+            $this->getProvisioner()->generateAdapter()->getAdapterFactory()->getSuperqueuer(),
+            $this->getProvisioner()->generateAdapter()->getAdapterFactory()->getSuperqueuer(),
+            $this->getProvisioner()->generateAdapter()->getAdapterFactory()->getSuperqueuer(),
         ];
 
         $this->assertTrue($connections[0]->requestAdvisoryLock('test', 'lock'));
@@ -148,10 +148,12 @@ abstract class SuperqueuerTest extends PHPUnit_Framework_TestCase
      */
     private function markJobsAsQueued($jobs)
     {
+        $adapter = $this->getProvisioner()->getAdapter();
+
         $jobs_queued = [];
 
         foreach ($jobs as $job) {
-            $meta = $this->getProvisioner()->getAdapter()->markJobAsQueued($job);
+            $meta = $adapter->getAdapterFactory()->getSuperqueuer()->markJobAsQueued($job);
             $jobs_queued[] = $meta;
         }
 


### PR DESCRIPTION
When it is time for PgsqlAdapter and the ConverterAdapter
to go away, it will be easier to transition if the old
adapters are only being used to retrieve the newer adapter
factory
