### PR TITLE
Only log job failure if error resulted in shutdown

### DIFF
--- a/src/Hodor/JobQueue/WorkerQueue.php
+++ b/src/Hodor/JobQueue/WorkerQueue.php
@@ -52,13 +52,14 @@ class WorkerQueue
 
             register_shutdown_function(
                 function (IncomingMessage $message, DateTime $start_time, QueueManager $queue_manager) {
-                    if (error_get_last()) {
-                        $queue_manager->getSuperqueue()->markJobAsFailed(
-                            $message,
-                            $start_time
-                        );
-                        exit(1);
+                    if ($message->isAcked()) {
+                        return;
                     }
+
+                    $queue_manager->getSuperqueue()->markJobAsFailed(
+                        $message,
+                        $start_time
+                    );
                 },
                 $message,
                 $start_time,

--- a/src/Hodor/MessageQueue/IncomingMessage.php
+++ b/src/Hodor/MessageQueue/IncomingMessage.php
@@ -59,4 +59,12 @@ class IncomingMessage
 
         $this->was_acked = true;
     }
+
+    /**
+     * @return bool
+     */
+    public function isAcked()
+    {
+        return $this->was_acked;
+    }
 }


### PR DESCRIPTION
During shutdown the worker has been checking for error
and attempting to mark the job as failed if there was
an error.  Sometimes an error occurs that does not result
in the job being terminated early, such as an undefined
variable.  In that case, the job will already have been
marked as successful, but the registered shutdown function
has been also trying to mark it as a failure.

Instead of attempting to mark the job as a failure any
time an error occurs, only mark the job as a failure if
it has not already been acknowledged.
