### PR TITLE
Add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# 0.2.0 release notes
+
+Breaking Changes:
+
+ - Upgraded Hodor's dependency on lightster/yo-pdo to v0.1.3+ from v0.0.2+
+
+Bug Fixes:
+
+ - Stop attempting to mark job as failed if it has already been marked as successful (#213)
+
+Other Changes:
+
+ - Refactored internals on a massive scale
+ - Increased testing coverage
+ - Improved PHPdoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Breaking Changes:
 
 Bug Fixes:
 
- - Stop attempting to mark job as failed if it has already been marked as successful (#213)
+ - Stop attempting to mark job as failed if it has already been marked as successful
+   ([#213](https://github.com/lightster/hodor/pull/213))
 
 Other Changes:
 


### PR DESCRIPTION
Creating release notes right now is painful.  Having a
CHANGELOG that can be updated when pull requests are
submitted will hopefully make life a bit easier.
