### PR TITLE
Throw more specific exception in MessageBank

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Testing/Exception/EmptyQueueException.php
+++ b/src/Hodor/MessageQueue/Adapter/Testing/Exception/EmptyQueueException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Testing\Exception;
+
+use Exception;
+
+class EmptyQueueException extends Exception
+{
+}

--- a/src/Hodor/MessageQueue/Adapter/Testing/MessageBank.php
+++ b/src/Hodor/MessageQueue/Adapter/Testing/MessageBank.php
@@ -3,6 +3,7 @@
 namespace Hodor\MessageQueue\Adapter\Testing;
 
 use Exception;
+use Hodor\MessageQueue\Adapter\Testing\Exception\EmptyQueueException;
 
 class MessageBank
 {
@@ -52,7 +53,7 @@ class MessageBank
 
     /**
      * @return Message
-     * @throws Exception
+     * @throws EmptyQueueException
      */
     public function consumeMessage()
     {
@@ -63,7 +64,7 @@ class MessageBank
             }
         }
 
-        throw new Exception("There are no messages to consume.");
+        throw new EmptyQueueException("There are no messages to consume.");
     }
 
     public function emulateReconnect()

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/MessageBankTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/MessageBankTest.php
@@ -64,7 +64,7 @@ class MessageBankTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers ::consumeMessage
-     * @expectedException Exception
+     * @expectedException \Hodor\MessageQueue\Adapter\Testing\Exception\EmptyQueueException
      */
     public function testConsumingWhileNoMessagesAreQueuedThrowsAnException()
     {
@@ -111,7 +111,7 @@ class MessageBankTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::consumeMessage
      * @covers ::produceMessage
-     * @expectedException Exception
+     * @expectedException \Hodor\MessageQueue\Adapter\Testing\Exception\EmptyQueueException
      */
     public function testConsumingWhileNoUnreceivedMessagesAreQueuedThrowsAnException()
     {


### PR DESCRIPTION
If there are no jobs to consume, we need to be able to handle
that versus handling other exceptions
