### PR TITLE
Set MessageBankFactory config outside constructor

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Testing/Factory.php
+++ b/src/Hodor/MessageQueue/Adapter/Testing/Factory.php
@@ -36,7 +36,9 @@ class Factory implements FactoryInterface
     public function __construct(ConfigInterface $config, MessageBankFactory $message_bank_factory = null)
     {
         $this->config = $config;
-        $this->message_bank_factory = $message_bank_factory ?: new MessageBankFactory($config);
+        $this->message_bank_factory = $message_bank_factory ?: new MessageBankFactory();
+
+        $this->message_bank_factory->setConfig($config);
     }
 
     /**

--- a/src/Hodor/MessageQueue/Adapter/Testing/MessageBankFactory.php
+++ b/src/Hodor/MessageQueue/Adapter/Testing/MessageBankFactory.php
@@ -2,6 +2,7 @@
 
 namespace Hodor\MessageQueue\Adapter\Testing;
 
+use Exception;
 use Hodor\MessageQueue\Adapter\ConfigInterface;
 
 class MessageBankFactory
@@ -17,9 +18,24 @@ class MessageBankFactory
     private $message_banks = [];
 
     /**
+     * @return ConfigInterface
+     * @throws Exception
+     */
+    public function getConfig()
+    {
+        if (!$this->config) {
+            throw new Exception(
+                'A ConfigInterface must be provided to the MessageBankFactory via setConfig()'
+            );
+        }
+
+        return $this->config;
+    }
+
+    /**
      * @param ConfigInterface $config
      */
-    public function __construct(ConfigInterface $config)
+    public function setConfig(ConfigInterface $config)
     {
         $this->config = $config;
     }
@@ -34,7 +50,7 @@ class MessageBankFactory
             return $this->message_banks[$queue_key];
         }
 
-        $this->message_banks[$queue_key] = new MessageBank($this->config->getQueueConfig($queue_key));
+        $this->message_banks[$queue_key] = new MessageBank($this->getConfig()->getQueueConfig($queue_key));
 
         return $this->message_banks[$queue_key];
     }

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/MessageBankFactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/MessageBankFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Hodor\MessageQueue\Adapter\Testing;
 
+use Exception;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -10,39 +11,52 @@ use PHPUnit_Framework_TestCase;
 class MessageBankFactoryTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var Config
+     * @var MessageBankFactory
      */
-    private $config;
+    private $message_bank_factory;
 
     public function setUp()
     {
-        $this->config = new Config(function () {});
-        $this->config->addQueueConfig('test-queue', ['workers_per_server' => 5]);
+        $config = new Config(function () {});
+        $config->addQueueConfig('test-queue', ['workers_per_server' => 5]);
+
+        $this->message_bank_factory = new MessageBankFactory();
+        $this->message_bank_factory->setConfig($config);
     }
 
     /**
-     * @covers ::__construct
+     * @covers ::getConfig
+     * @covers ::setConfig
      * @covers ::getMessageBank
      */
     public function testMessageBankCanBeRetrieved()
     {
-        $message_bank_factory = new MessageBankFactory($this->config);
         $this->assertInstanceOf(
             'Hodor\MessageQueue\Adapter\Testing\MessageBank',
-            $message_bank_factory->getMessageBank('test-queue')
+            $this->message_bank_factory->getMessageBank('test-queue')
         );
     }
 
     /**
-     * @covers ::__construct
+     * @covers ::getConfig
+     * @covers ::setConfig
      * @covers ::getMessageBank
      */
     public function testMessageBankIsReused()
     {
-        $message_bank_factory = new MessageBankFactory($this->config);
         $this->assertSame(
-            $message_bank_factory->getMessageBank('test-queue'),
-            $message_bank_factory->getMessageBank('test-queue')
+            $this->message_bank_factory->getMessageBank('test-queue'),
+            $this->message_bank_factory->getMessageBank('test-queue')
         );
+    }
+
+    /**
+     * @covers ::getConfig
+     * @expectedException Exception
+     */
+    public function testConfigCannotBeRetrievedIfItIsNotSet()
+    {
+        $message_bank_factory = new MessageBankFactory();
+        $message_bank_factory->getConfig();
     }
 }


### PR DESCRIPTION
Unfortunately there is a circular dependency between
the MessageBankFactory and the MessageQueueConfig
right now.  The MessageBankFactory needs to be able
to access the queue configs, but the MessageQueueConfig
also needs to be able to return the message queue
adapter factory config (which includes the
MessageBankFactory).
