### PR TITLE
Generate MQ adapter factory in new AdapterFactory

### DIFF
--- a/src/Hodor/JobQueue/Config.php
+++ b/src/Hodor/JobQueue/Config.php
@@ -87,7 +87,7 @@ class Config
 
         $this->message_queue_config = new MessageQueueConfig(
             $this->getQueueConfig(),
-            $this->getOption('adapter_factory')
+            $this->getOption('message_queue_factory', [])
         );
 
         return $this->message_queue_config;

--- a/src/Hodor/JobQueue/Config/MessageQueueConfig.php
+++ b/src/Hodor/JobQueue/Config/MessageQueueConfig.php
@@ -3,22 +3,14 @@
 namespace Hodor\JobQueue\Config;
 
 use Exception;
-use Hodor\MessageQueue\Adapter\Amqp\Factory as AmqpFactory;
 use Hodor\MessageQueue\Adapter\ConfigInterface;
-use Hodor\MessageQueue\Adapter\FactoryInterface;
-use Hodor\MessageQueue\Adapter\Testing\Factory as TestingFactory;
 
 class MessageQueueConfig implements ConfigInterface
 {
     /**
      * @var string
      */
-    private $adapter_factory_type;
-
-    /**
-     * @var FactoryInterface
-     */
-    private $adapter_factory;
+    private $adapter_factory_config;
 
     /**
      * @var QueueConfig
@@ -27,26 +19,23 @@ class MessageQueueConfig implements ConfigInterface
 
     /**
      * @param QueueConfig $queue_config
-     * @param string $adapter_factory_type
+     * @param array $adapter_factory_config
      */
-    public function __construct(QueueConfig $queue_config, $adapter_factory_type = null)
+    public function __construct(QueueConfig $queue_config, array $adapter_factory_config = [])
     {
-        $this->adapter_factory_type = $adapter_factory_type ?: 'amqp';
+        $this->adapter_factory_config = array_merge(
+            ['type' => 'amqp'],
+            $adapter_factory_config
+        );
         $this->queue_config = $queue_config;
     }
 
     /**
-     * @return FactoryInterface
+     * @return array
      */
-    public function getAdapterFactory()
+    public function getAdapterFactoryConfig()
     {
-        if ($this->adapter_factory) {
-            return $this->adapter_factory;
-        }
-
-        $this->adapter_factory = $this->generateAdapterFactory();
-
-        return $this->adapter_factory;
+        return $this->adapter_factory_config;
     }
 
     /**
@@ -57,17 +46,5 @@ class MessageQueueConfig implements ConfigInterface
     public function getQueueConfig($queue_name)
     {
         return $this->queue_config->getMessageQueueConfig($queue_name);
-    }
-
-    /**
-     * @return FactoryInterface
-     */
-    private function generateAdapterFactory()
-    {
-        if ('testing' === $this->adapter_factory_type) {
-            return new TestingFactory($this);
-        }
-
-        return new AmqpFactory($this);
     }
 }

--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -4,6 +4,7 @@ namespace Hodor\JobQueue;
 
 use Hodor\Database\Adapter\FactoryInterface;
 use Hodor\Database\AdapterFactory as DbAdapterFactory;
+use Hodor\MessageQueue\AdapterFactory;
 use Hodor\MessageQueue\Queue as MessageQueue;
 use Hodor\MessageQueue\QueueFactory as MqFactory;
 
@@ -160,7 +161,9 @@ class QueueManager
             return $this->mq_factory;
         }
 
-        $this->mq_factory = new MqFactory($this->config->getMessageQueueConfig());
+        $mq_adapter_factory = new AdapterFactory();
+        $mq_adapter = $mq_adapter_factory->getAdapter($this->config->getMessageQueueConfig());
+        $this->mq_factory = new MqFactory($mq_adapter);
 
         return $this->mq_factory;
     }

--- a/src/Hodor/MessageQueue/Adapter/ConfigInterface.php
+++ b/src/Hodor/MessageQueue/Adapter/ConfigInterface.php
@@ -5,9 +5,9 @@ namespace Hodor\MessageQueue\Adapter;
 interface ConfigInterface
 {
     /**
-     * @return FactoryInterface
+     * @return string
      */
-    public function getAdapterFactory();
+    public function getAdapterFactoryConfig();
 
     /**
      * @param string $queue_name

--- a/src/Hodor/MessageQueue/Adapter/Testing/Config.php
+++ b/src/Hodor/MessageQueue/Adapter/Testing/Config.php
@@ -3,15 +3,14 @@
 namespace Hodor\MessageQueue\Adapter\Testing;
 
 use Hodor\MessageQueue\Adapter\ConfigInterface;
-use Hodor\MessageQueue\Adapter\FactoryInterface;
 use OutOfBoundsException;
 
 class Config implements ConfigInterface
 {
     /**
-     * @var FactoryInterface
+     * @var array
      */
-    private $adapter_factory;
+    private $adapter_factory_config;
 
     /**
      * @var array
@@ -19,31 +18,19 @@ class Config implements ConfigInterface
     private $queues = [];
 
     /**
-     * @var callable
+     * @param array $adapter_factory_config
      */
-    private $adapter_factory_generator;
-
-    /**
-     * @param callable $adapter_factory_generator
-     */
-    public function __construct(callable $adapter_factory_generator)
+    public function __construct(array $adapter_factory_config)
     {
-        $this->adapter_factory_generator = $adapter_factory_generator;
+        $this->adapter_factory_config = $adapter_factory_config;
     }
 
     /**
-     * @return FactoryInterface
+     * @return array
      */
-    public function getAdapterFactory()
+    public function getAdapterFactoryConfig()
     {
-        if ($this->adapter_factory) {
-            return $this->adapter_factory;
-        }
-
-        $adapter_factory_generator = $this->adapter_factory_generator;
-        $this->adapter_factory = $adapter_factory_generator($this);
-
-        return $this->adapter_factory;
+        return $this->adapter_factory_config;
     }
 
     /**

--- a/src/Hodor/MessageQueue/AdapterFactory.php
+++ b/src/Hodor/MessageQueue/AdapterFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Hodor\MessageQueue;
+
+use Exception;
+use Hodor\MessageQueue\Adapter\Amqp\Factory as AmqpFactory;
+use Hodor\MessageQueue\Adapter\ConfigInterface;
+use Hodor\MessageQueue\Adapter\Testing\Factory as TestingFactory;
+use Hodor\MessageQueue\Adapter\FactoryInterface;
+
+class AdapterFactory
+{
+    /**
+     * @param ConfigInterface $mq_config
+     * @return FactoryInterface
+     * @throws Exception
+     */
+    public function getAdapter(ConfigInterface $mq_config)
+    {
+        $config = $mq_config->getAdapterFactoryConfig();
+
+        if (empty($config['type'])) {
+            throw new Exception(
+                "The message queue 'type' must provided in connection config."
+            );
+        }
+
+        if ('testing' === $config['type']) {
+            return $this->getTestingFactory($mq_config, $config);
+        }
+
+        if ('amqp' === $config['type']) {
+            return new AmqpFactory($mq_config);
+        }
+
+        throw new Exception("A message queue adapter factory is not associated with '{$config['type']}'.");
+    }
+
+    /**
+     * @param ConfigInterface $mq_config
+     * @param array $config
+     * @return TestingFactory
+     */
+    private function getTestingFactory(ConfigInterface $mq_config, array $config)
+    {
+        $message_bank_factory = null;
+        extract($config, EXTR_IF_EXISTS);
+
+        return new TestingFactory($mq_config, $message_bank_factory);
+    }
+}

--- a/src/Hodor/MessageQueue/QueueFactory.php
+++ b/src/Hodor/MessageQueue/QueueFactory.php
@@ -2,16 +2,10 @@
 
 namespace Hodor\MessageQueue;
 
-use Hodor\MessageQueue\Adapter\ConfigInterface;
 use Hodor\MessageQueue\Adapter\FactoryInterface;
 
 class QueueFactory
 {
-    /**
-     * @var ConfigInterface
-     */
-    private $config;
-
     /**
      * @var FactoryInterface
      */
@@ -28,11 +22,11 @@ class QueueFactory
     private $is_in_batch = false;
 
     /**
-     * @param ConfigInterface $config
+     * @param FactoryInterface $adapter_factory
      */
-    public function __construct(ConfigInterface $config)
+    public function __construct(FactoryInterface $adapter_factory)
     {
-        $this->config = $config;
+        $this->adapter_factory = $adapter_factory;
     }
 
     /**
@@ -85,12 +79,6 @@ class QueueFactory
      */
     private function getAdapterFactory()
     {
-        if ($this->adapter_factory) {
-            return $this->adapter_factory;
-        }
-
-        $this->adapter_factory = $this->config->getAdapterFactory();
-
         return $this->adapter_factory;
     }
 }

--- a/tests/src/Hodor/JobQueue/Config/MessageQueueConfigTest.php
+++ b/tests/src/Hodor/JobQueue/Config/MessageQueueConfigTest.php
@@ -3,6 +3,7 @@
 namespace Hodor\JobQueue\Config;
 
 use Exception;
+use Hodor\MessageQueue\Adapter\Testing\MessageBankFactory;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -50,43 +51,35 @@ class MessageQueueConfigTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::generateAdapterFactory
-     * @covers ::getAdapterFactory
+     * @covers ::getAdapterFactoryConfig
      * @covers ::<private>
      */
     public function testAdapterFactoryCanBeRetrieved()
     {
-        $this->assertInstanceOf(
-            'Hodor\MessageQueue\Adapter\Amqp\Factory',
-            (new MessageQueueConfig(new QueueConfig([])))->getAdapterFactory()
+        $this->assertEquals(
+            ['type' => 'amqp'],
+            (new MessageQueueConfig(new QueueConfig([])))->getAdapterFactoryConfig()
         );
     }
 
     /**
-     * @covers ::generateAdapterFactory
-     * @covers ::getAdapterFactory
-     * @covers ::<private>
-     */
-    public function testAdapterFactoryIsReused()
-    {
-        $config = new MessageQueueConfig(new QueueConfig([]));
-
-        $this->assertSame(
-            $config->getAdapterFactory(),
-            $config->getAdapterFactory()
-        );
-    }
-
-    /**
-     * @covers ::generateAdapterFactory
-     * @covers ::getAdapterFactory
+     * @covers ::getAdapterFactoryConfig
      * @covers ::<private>
      */
     public function testTestingAdapterFactoryCanBeRetrieved()
     {
-        $this->assertInstanceOf(
-            'Hodor\MessageQueue\Adapter\Testing\Factory',
-            (new MessageQueueConfig(new QueueConfig([]), 'testing'))->getAdapterFactory()
+        $message_bank_factory = new MessageBankFactory();
+
+        $adapter_factory_config = [
+            'type'                 => 'testing',
+            'message_bank_factory' => $message_bank_factory,
+        ];
+        $message_queue_config = new MessageQueueConfig(new QueueConfig([]), $adapter_factory_config);
+        $message_bank_factory->setConfig($message_queue_config);
+
+        $this->assertEquals(
+            $adapter_factory_config,
+            $message_queue_config->getAdapterFactoryConfig()
         );
     }
 

--- a/tests/src/Hodor/JobQueue/ConfigTest.php
+++ b/tests/src/Hodor/JobQueue/ConfigTest.php
@@ -166,9 +166,9 @@ class ConfigTest extends PHPUnit_Framework_TestCase
             ]
         );
 
-        $this->assertInstanceOf(
-            'Hodor\MessageQueue\Adapter\Testing\Factory',
-            $config->getMessageQueueConfig()->getAdapterFactory()
+        $this->assertEquals(
+            ['type' => 'testing'],
+            $config->getMessageQueueConfig()->getAdapterFactoryConfig()
         );
     }
 
@@ -270,7 +270,9 @@ class ConfigTest extends PHPUnit_Framework_TestCase
                         'dsn'  => 'host=localhost user=test_hodor dbname=test_hodor',
                     ],
                 ],
-                'adapter_factory' => 'testing',
+                'message_queue_factory' => [
+                    'type' => 'testing'
+                ],
                 'queue_defaults' => [
                     'host' => 'queue-default-host',
                 ],

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConfigProvider.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConfigProvider.php
@@ -27,9 +27,7 @@ class ConfigProvider
      */
     public function getConfigAdapter(array $queues, array $config_overrides = [])
     {
-        $config = new Config(function () {
-            return $this->test_case->getMock('Hodor\MessageQueue\Adapter\FactoryInterface');
-        });
+        $config = new Config([]);
         foreach ($queues as $queue_key => $queue_config) {
             $config->addQueueConfig($queue_key, array_merge($queue_config, $config_overrides));
         }

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/ConfigTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/ConfigTest.php
@@ -2,7 +2,6 @@
 
 namespace Hodor\MessageQueue\Adapter\Testing;
 
-use Hodor\MessageQueue\Adapter\FactoryInterface;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -12,43 +11,14 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @covers ::__construct
-     * @covers ::getAdapterFactory
+     * @covers ::getAdapterFactoryConfig
      */
     public function testAdapterFactoryReturnedIsSameReturnedByFactoryGenerator()
     {
-        $adapter_factory = $this->getAdapterFactoryMock();
-        $config = new Config(function () use ($adapter_factory) {
-            return $adapter_factory;
-        });
+        $adapter_factory_config = $this->getAdapterFactoryConfig();
+        $config = new Config($adapter_factory_config);
 
-        $this->assertSame($adapter_factory, $config->getAdapterFactory());
-    }
-
-    /**
-     * @covers ::__construct
-     * @covers ::getAdapterFactory
-     */
-    public function testAdapterFactoryIsLazyLoaded()
-    {
-        $config = new Config(function () {
-            return $this->getAdapterFactoryMock();
-        });
-
-        $this->assertSame($config->getAdapterFactory(), $config->getAdapterFactory());
-    }
-
-    /**
-     * @covers ::__construct
-     * @covers ::getAdapterFactory
-     */
-    public function testAdapterFactoryReturnedIsSameProvidedToConstructor()
-    {
-        $adapter_factory = $this->getAdapterFactoryMock();
-        $config = new Config(function () use ($adapter_factory) {
-            return $adapter_factory;
-        });
-
-        $this->assertSame($adapter_factory, $config->getAdapterFactory());
+        $this->assertSame($adapter_factory_config, $config->getAdapterFactoryConfig());
     }
 
     /**
@@ -59,9 +29,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      */
     public function testRetrievingUndefinedQueueThrowsAnException($queue_key)
     {
-        $config = new Config(function () {
-            return $this->getAdapterFactoryMock();
-        });
+        $config = new Config($this->getAdapterFactoryConfig());
 
         $config->getQueueConfig($queue_key);
     }
@@ -75,9 +43,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      */
     public function testAddedQueueConfigCanBeRetrieved($queue_key, array $queue_config)
     {
-        $config = new Config(function () {
-            return $this->getAdapterFactoryMock();
-        });
+        $config = new Config($this->getAdapterFactoryConfig());
 
         $config->addQueueConfig($queue_key, $queue_config);
         $this->assertEquals($queue_config, $config->getQueueConfig($queue_key));
@@ -92,10 +58,13 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return FactoryInterface
+     * @return array
      */
-    private function getAdapterFactoryMock()
+    private function getAdapterFactoryConfig()
     {
-        return $this->getMock('Hodor\MessageQueue\Adapter\FactoryInterface');
+        return [
+            'type'                 => 'testing',
+            'message_bank_factory' => new MessageBankFactory(),
+        ];
     }
 }

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/MessageBankFactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/MessageBankFactoryTest.php
@@ -17,7 +17,7 @@ class MessageBankFactoryTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $config = new Config(function () {});
+        $config = new Config([]);
         $config->addQueueConfig('test-queue', ['workers_per_server' => 5]);
 
         $this->message_bank_factory = new MessageBankFactory();

--- a/tests/src/Hodor/MessageQueue/AdapterFactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/AdapterFactoryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Hodor\MessageQueue;
+
+use Exception;
+use Hodor\MessageQueue\Adapter\Testing\Config;
+use Hodor\MessageQueue\Adapter\Testing\Consumer;
+use Hodor\MessageQueue\Adapter\Testing\MessageBank;
+use Hodor\MessageQueue\Adapter\Testing\Producer;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @coversDefaultClass Hodor\MessageQueue\AdapterFactory
+ */
+class AdapterFactoryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::getAdapter
+     * @covers ::<private>
+     * @expectedException Exception
+     */
+    public function testExceptionIsThrownIfAdapterTypeIsNotProvided()
+    {
+        $factory = new AdapterFactory();
+        $config = new Config([]);
+
+        $factory->getAdapter($config);
+    }
+
+    /**
+     * @covers ::getAdapter
+     * @covers ::<private>
+     * @expectedException Exception
+     */
+    public function testExceptionIsThrownIfUnknownAdapterTypeIsProvided()
+    {
+        $factory = new AdapterFactory();
+        $config = new Config(['type' => 'unknown']);
+
+        $factory->getAdapter($config);
+    }
+
+    /**
+     * @covers ::getAdapter
+     * @covers ::<private>
+     */
+    public function testTestingAdapterCanBeGenerated()
+    {
+        $factory = new AdapterFactory();
+        $config = new Config(['type' => 'testing']);
+
+        $this->assertInstanceOf(
+            'Hodor\MessageQueue\Adapter\Testing\Factory',
+            $factory->getAdapter($config)
+        );
+    }
+
+    /**
+     * @covers ::getAdapter
+     * @covers ::<private>
+     */
+    public function testAmqpAdapterCanBeGenerated()
+    {
+        $factory = new AdapterFactory();
+        $config = new Config(['type' => 'amqp']);
+
+        $this->assertInstanceOf(
+            'Hodor\MessageQueue\Adapter\Amqp\Factory',
+            $factory->getAdapter($config)
+        );
+    }
+}

--- a/tests/src/Hodor/MessageQueue/QueueFactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/QueueFactoryTest.php
@@ -138,12 +138,10 @@ class QueueFactoryTest extends PHPUnit_Framework_TestCase
     {
         $config_provider = new ConfigProvider($this);
 
-        $config = new Config(function (Config $config) {
-            return new Factory($config);
-        });
+        $config = new Config([]);
         $config->addQueueConfig('fast_jobs', $config_provider->getQueueConfig());
         $config->addQueueConfig('slow_jobs', $config_provider->getQueueConfig());
 
-        return new QueueFactory($config);
+        return new QueueFactory(new Factory($config));
     }
 }


### PR DESCRIPTION
Rather than generating the MQ adapter factory in the
MessageQueueConfig, we now have an object dedicated
to generating the MessageQueue\FactoryInterface objects
