### PR TITLE
Add BatchManager

### DIFF
--- a/src/Hodor/MessageQueue/BatchManager.php
+++ b/src/Hodor/MessageQueue/BatchManager.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Hodor\MessageQueue;
+
+use Exception;
+
+class BatchManager
+{
+    /**
+     * @var QueueFactory
+     */
+    private $queue_factory;
+
+    /**
+     * @var bool
+     */
+    private $is_in_batch = false;
+
+    /**
+     * @var array
+     */
+    private $batches = [];
+
+    /**
+     * @param QueueFactory $queue_factory
+     */
+    public function __construct(QueueFactory $queue_factory)
+    {
+        $this->queue_factory = $queue_factory;
+    }
+
+    /**
+     * @param $queue_name
+     * @param mixed $message
+     */
+    public function push($queue_name, $message)
+    {
+        $this->checkQueueName($queue_name);
+
+        if ($this->is_in_batch) {
+            $this->batches[$queue_name][] = $message;
+            return;
+        }
+
+        $this->queue_factory->getQueue($queue_name)->publishMessage($message);
+    }
+
+    public function beginBatch()
+    {
+        if ($this->is_in_batch) {
+            throw new Exception("The queue is already in transaction.");
+        }
+
+        $this->is_in_batch = true;
+    }
+
+    public function publishBatch()
+    {
+        if (!$this->is_in_batch) {
+            throw new Exception("The queue is not in transaction.");
+        }
+
+        foreach ($this->batches as $queue_name => $batch) {
+            $this->queue_factory->getQueue($queue_name)->publishMessageBatch($batch);
+        }
+
+        $this->is_in_batch = false;
+        $this->batches = [];
+    }
+
+    public function discardBatch()
+    {
+        if (!$this->is_in_batch) {
+            throw new Exception("The queue is not in transaction.");
+        }
+
+        $this->is_in_batch = false;
+        $this->batches = [];
+    }
+
+    /**
+     * @param string $queue_name
+     */
+    private function checkQueueName($queue_name)
+    {
+        $this->queue_factory->getQueue($queue_name);
+    }
+}

--- a/src/Hodor/MessageQueue/Queue.php
+++ b/src/Hodor/MessageQueue/Queue.php
@@ -49,7 +49,28 @@ class Queue
             return;
         }
 
+        $this->publishMessage($message);
+    }
+
+    /**
+     * @param  mixed $message
+     */
+    public function publishMessage($message)
+    {
         $this->producer->produceMessage(new OutgoingMessage($message));
+    }
+
+    /**
+     * @param array $raw_messages
+     */
+    public function publishMessageBatch(array $raw_messages)
+    {
+        $messages = [];
+        foreach ($raw_messages as $message) {
+            $messages[] = new OutgoingMessage($message);
+        }
+
+        $this->producer->produceMessageBatch($messages);
     }
 
     /**

--- a/tests/src/Hodor/MessageQueue/BatchManagerTest.php
+++ b/tests/src/Hodor/MessageQueue/BatchManagerTest.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace Hodor\MessageQueue;
+
+use Exception;
+use Hodor\MessageQueue\Adapter\Testing\Config;
+use Hodor\MessageQueue\Adapter\Testing\Factory;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @coversDefaultClass Hodor\MessageQueue\BatchManager
+ */
+class BatchManagerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Factory
+     */
+    private $adapter_factory;
+
+    /**
+     * @var QueueFactory
+     */
+    private $queue_factory;
+
+    /**
+     * @var BatchManager
+     */
+    private $batch_manager;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $config = new Config([]);
+        $config->addQueueConfig('some-queue-name', []);
+        $this->adapter_factory = new Factory($config);
+        $this->queue_factory = new QueueFactory($this->adapter_factory);
+        $this->batch_manager = new BatchManager($this->queue_factory);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::push
+     * @covers ::<private>
+     * @expectedException Exception
+     */
+    public function testQueueingAMessageForANonExistentQueueThrowsAnException()
+    {
+        $this->batch_manager->push('non-existent-queue-name', 1);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::push
+     * @covers ::<private>
+     */
+    public function testMessagesCanBeProducedOutsideOfBatch()
+    {
+        $expected = ['name' => __METHOD__, 'number' => 1];
+
+        $this->batch_manager->push('some-queue-name', $expected);
+
+        $queue = $this->queue_factory->getQueue('some-queue-name');
+        $queue->consume(function (IncomingMessage $message) use ($expected) {
+            $this->assertSame($expected, $message->getContent());
+            $message->acknowledge();
+        });
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::push
+     * @covers ::beginBatch
+     * @expectedException Exception
+     */
+    public function testMessagesPushedInsideOfBatchAreNotImmediatelyProduced()
+    {
+        $this->batch_manager->beginBatch();
+        for ($i = 1; $i <= 2; $i++) {
+            $this->batch_manager->push('some-queue-name', $i);
+        }
+
+        $queue = $this->queue_factory->getQueue('some-queue-name');
+        $queue->consume(function () {
+            $this->fail('A message should not be consumed');
+        });
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::push
+     * @covers ::beginBatch
+     * @expectedException Exception
+     */
+    public function testStartingABatchWhileABatchIsAlreadyStartedThrowsAnException()
+    {
+        $this->batch_manager->beginBatch();
+        $this->batch_manager->beginBatch();
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::push
+     * @covers ::beginBatch
+     * @covers ::publishBatch
+     */
+    public function testMessagesPushedInsideOfBatchAreAvailableAfterBatchIsPublished()
+    {
+        $this->batch_manager->beginBatch();
+        for ($i = 1; $i <= 2; $i++) {
+            $this->batch_manager->push('some-queue-name', $i);
+        }
+        $this->batch_manager->publishBatch();
+
+        $count = 0;
+        $queue = $this->queue_factory->getQueue('some-queue-name');
+        $queue->consume(function (IncomingMessage $message) use (&$count) {
+            ++$count;
+            $message->acknowledge();
+        });
+        $queue->consume(function (IncomingMessage $message) use (&$count) {
+            ++$count;
+            $message->acknowledge();
+        });
+
+        $this->assertSame(2, $count);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::push
+     * @covers ::beginBatch
+     * @covers ::publishBatch
+     * @expectedException Exception
+     */
+    public function testNoMessagesAreLeftToProduceAfterBatchIsPublished()
+    {
+        $this->batch_manager->beginBatch();
+        for ($i = 1; $i <= 2; $i++) {
+            $this->batch_manager->push('some-queue-name', $i);
+        }
+        $this->batch_manager->publishBatch();
+
+        $queue = $this->queue_factory->getQueue('some-queue-name');
+        $queue->consume(function (IncomingMessage $message) {
+            $message->acknowledge();
+        });
+        $queue->consume(function (IncomingMessage $message) {
+            $message->acknowledge();
+        });
+
+        $queue->consume(function () {
+        });
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::beginBatch
+     * @covers ::publishBatch
+     * @expectedException Exception
+     */
+    public function testPublishingABatchAfterItWasAlreadyPublishedThrowsAnException()
+    {
+        $this->batch_manager->beginBatch();
+        $this->batch_manager->publishBatch();
+        $this->batch_manager->publishBatch();
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::beginBatch
+     * @covers ::publishBatch
+     * @expectedException Exception
+     */
+    public function testANewBatchCanBeStartedAfterABatchHasAlreadyBeenPublished()
+    {
+        $this->batch_manager->beginBatch();
+        $this->batch_manager->publishBatch();
+        $this->batch_manager->beginBatch();
+
+        $this->batch_manager->push('some-queue-name', 1);
+
+        $queue = $this->queue_factory->getQueue('some-queue-name');
+        $queue->consume(function () {
+        });
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::push
+     * @covers ::beginBatch
+     * @covers ::discardBatch
+     * @expectedException Exception
+     */
+    public function testBatchedMessagesCanBeDiscarded()
+    {
+        $this->batch_manager->beginBatch();
+        $this->batch_manager->push('some-queue-name', 1);
+        $this->batch_manager->discardBatch();
+
+        $queue = $this->queue_factory->getQueue('some-queue-name');
+        $queue->consume(function () {
+            $this->fail('Discarded messages should not be available for consumption.');
+        });
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::discardBatch
+     * @expectedException Exception
+     */
+    public function testDiscardingABatchThatWasNeverStartedThrowsAnException()
+    {
+        $this->batch_manager->discardBatch();
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::beginBatch
+     * @covers ::discardBatch
+     * @expectedException Exception
+     */
+    public function testDiscardingABatchAfterItWasAlreadyDiscardedThrowsAnException()
+    {
+        $this->batch_manager->beginBatch();
+        $this->batch_manager->discardBatch();
+        $this->batch_manager->discardBatch();
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::beginBatch
+     * @covers ::discardBatch
+     * @expectedException Exception
+     */
+    public function testDiscardingABatchAfterItWasAlreadyPublishedThrowsAnException()
+    {
+        $this->batch_manager->beginBatch();
+        $this->batch_manager->publishBatch();
+        $this->batch_manager->discardBatch();
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::beginBatch
+     * @covers ::discardBatch
+     * @expectedException Exception
+     */
+    public function testPublishingABatchAfterItWasAlreadyDiscardedThrowsAnException()
+    {
+        $this->batch_manager->beginBatch();
+        $this->batch_manager->publishBatch();
+        $this->batch_manager->discardBatch();
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::beginBatch
+     * @covers ::discardBatch
+     * @expectedException Exception
+     */
+    public function testANewBatchCanBeStartedAfterABatchHasAlreadyBeenDiscarded()
+    {
+        $this->batch_manager->beginBatch();
+        $this->batch_manager->discardBatch();
+        $this->batch_manager->beginBatch();
+
+        $this->batch_manager->push('some-queue-name', 1);
+
+        $queue = $this->queue_factory->getQueue('some-queue-name');
+        $queue->consume(function () {
+        });
+    }
+}

--- a/tests/src/Hodor/MessageQueue/QueueTest.php
+++ b/tests/src/Hodor/MessageQueue/QueueTest.php
@@ -335,6 +335,46 @@ class QueueTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers ::__construct
+     * @covers ::publishMessage
+     * @depends testMessageCanBeConsumed
+     */
+    public function testIndividualMessageCanBePublished()
+    {
+        $message_bank = new MessageBank();
+        $queue = $this->getQueue($message_bank);
+
+        $expected = ['name' => __METHOD__, 'number' => 1];
+
+        $queue->publishMessage($expected);
+        $queue->consume(function (IncomingMessage $message) use ($expected) {
+            $this->assertSame($expected, $message->getContent());
+            $message->acknowledge();
+        });
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::publishMessageBatch
+     * @depends testMessageCanBeConsumed
+     */
+    public function testMessageBatchesCanBePublished()
+    {
+        $message_bank = new MessageBank(['max_messages_per_consume' => 2]);
+        $queue = $this->getQueue($message_bank);
+
+        $queue->publishMessageBatch([1, 2]);
+
+        $count = 0;
+        $queue->consume(function (IncomingMessage $message) use (&$count) {
+            ++$count;
+            $message->acknowledge();
+        });
+
+        $this->assertSame(2, $count);
+    }
+
+    /**
      * @param MessageBank $message_bank
      * @return Queue
      */


### PR DESCRIPTION
The BatchManager is not tied to a specific queue, so
there is not the complexity of some queues having a
batch started and some not. Multiple BatchManagers can
be used if some queues need to be published to outside
of a batch and other queues need to be published to
inside of a batch.
