### PR TITLE
Allow queues without queue options

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Testing/Config.php
+++ b/src/Hodor/MessageQueue/Adapter/Testing/Config.php
@@ -48,7 +48,7 @@ class Config implements ConfigInterface
      */
     public function getQueueConfig($queue_key)
     {
-        if (empty($this->queues[$queue_key])) {
+        if (!array_key_exists($queue_key, $this->queues)) {
             throw new OutOfBoundsException("Queue with '{$queue_key}' not found.");
         }
 

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/ConfigTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/ConfigTest.php
@@ -52,6 +52,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     public function queueConfigProvider()
     {
         return [
+            ['no-custom-params', []],
             ['default-queue-key', ['queue_name' => 'default-queue-name', 'host' => 'localhost']],
             [uniqid(), ['queue_name' => uniqid(), 'host' => uniqid()]],
         ];


### PR DESCRIPTION
Queues without queue options were causing "queue not found"
exceptions to be thrown
