### PR TITLE
Make BatchManager independent of Queue class

### DIFF
--- a/src/Hodor/MessageQueue/Queue.php
+++ b/src/Hodor/MessageQueue/Queue.php
@@ -49,28 +49,7 @@ class Queue
             return;
         }
 
-        $this->publishMessage($message);
-    }
-
-    /**
-     * @param  mixed $message
-     */
-    public function publishMessage($message)
-    {
         $this->producer->produceMessage(new OutgoingMessage($message));
-    }
-
-    /**
-     * @param array $raw_messages
-     */
-    public function publishMessageBatch(array $raw_messages)
-    {
-        $messages = [];
-        foreach ($raw_messages as $message) {
-            $messages[] = new OutgoingMessage($message);
-        }
-
-        $this->producer->produceMessageBatch($messages);
     }
 
     /**

--- a/tests/src/Hodor/MessageQueue/BatchManagerTest.php
+++ b/tests/src/Hodor/MessageQueue/BatchManagerTest.php
@@ -35,7 +35,7 @@ class BatchManagerTest extends PHPUnit_Framework_TestCase
         $config->addQueueConfig('some-queue-name', []);
         $this->adapter_factory = new Factory($config);
         $this->queue_factory = new QueueFactory($this->adapter_factory);
-        $this->batch_manager = new BatchManager($this->queue_factory);
+        $this->batch_manager = new BatchManager($this->adapter_factory);
     }
 
     /**

--- a/tests/src/Hodor/MessageQueue/QueueTest.php
+++ b/tests/src/Hodor/MessageQueue/QueueTest.php
@@ -335,46 +335,6 @@ class QueueTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::publishMessage
-     * @depends testMessageCanBeConsumed
-     */
-    public function testIndividualMessageCanBePublished()
-    {
-        $message_bank = new MessageBank();
-        $queue = $this->getQueue($message_bank);
-
-        $expected = ['name' => __METHOD__, 'number' => 1];
-
-        $queue->publishMessage($expected);
-        $queue->consume(function (IncomingMessage $message) use ($expected) {
-            $this->assertSame($expected, $message->getContent());
-            $message->acknowledge();
-        });
-    }
-
-    /**
-     * @covers ::__construct
-     * @covers ::publishMessageBatch
-     * @depends testMessageCanBeConsumed
-     */
-    public function testMessageBatchesCanBePublished()
-    {
-        $message_bank = new MessageBank(['max_messages_per_consume' => 2]);
-        $queue = $this->getQueue($message_bank);
-
-        $queue->publishMessageBatch([1, 2]);
-
-        $count = 0;
-        $queue->consume(function (IncomingMessage $message) use (&$count) {
-            ++$count;
-            $message->acknowledge();
-        });
-
-        $this->assertSame(2, $count);
-    }
-
-    /**
      * @param MessageBank $message_bank
      * @return Queue
      */


### PR DESCRIPTION
BatchManager is going to turn into a Producer
and QueueFactory is going to be removed in favor
of having Producer / Consumers completely separate.
The idea behind separating the two is that the two
serve different purposes, and we want to eventually
be able to batch produce on multiple queues at once
