### PR TITLE
Use Producer/Consumer for WorkerQueue

### DIFF
--- a/src/Hodor/JobQueue/Superqueue.php
+++ b/src/Hodor/JobQueue/Superqueue.php
@@ -8,11 +8,6 @@ use Hodor\Database\Adapter\SuperqueuerInterface;
 class Superqueue
 {
     /**
-     * @var QueueManager
-     */
-    private $queue_manager;
-
-    /**
      * @var FactoryInterface
      */
     private $database;
@@ -30,16 +25,11 @@ class Superqueue
     /**
      * @param SuperqueuerInterface $database
      * @param WorkerQueueFactory $worker_queue_factory
-     * @param QueueManager $queue_manager
      */
-    public function __construct(
-        SuperqueuerInterface $database,
-        WorkerQueueFactory $worker_queue_factory,
-        QueueManager $queue_manager
-    ) {
+    public function __construct(SuperqueuerInterface $database, WorkerQueueFactory $worker_queue_factory)
+    {
         $this->database = $database;
         $this->worker_queue_factory = $worker_queue_factory;
-        $this->queue_manager = $queue_manager;
     }
 
     /**
@@ -75,7 +65,7 @@ class Superqueue
         $db = $this->database;
 
         if (0 === $this->jobs_queued) {
-            $this->queue_manager->beginBatch();
+            $this->worker_queue_factory->beginBatch();
             $db->beginBatch();
         }
 
@@ -102,7 +92,7 @@ class Superqueue
         // message is pushed to Rabbit MQ to prevent jobs from being
         // processed by workers before they have been moved to buffered_jobs
         $this->database->publishBatch();
-        $this->queue_manager->publishBatch();
+        $this->worker_queue_factory->publishBatch();
 
         $this->jobs_queued = 0;
     }

--- a/tests/src/Hodor/JobQueue/TestUtil/TestingWorkerQueueFactory.php
+++ b/tests/src/Hodor/JobQueue/TestUtil/TestingWorkerQueueFactory.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Hodor\JobQueue\TestUtil;
+
+use Hodor\Database\Adapter\Testing\Database;
+use Hodor\Database\Adapter\Testing\Dequeuer;
+use Hodor\JobQueue\WorkerQueue;
+use Hodor\JobQueue\WorkerQueueFactory;
+use Hodor\MessageQueue\Adapter\Testing\Config as TestingConfig;
+use Hodor\MessageQueue\Adapter\Testing\Factory;
+use Hodor\MessageQueue\Adapter\Testing\MessageBank;
+use Hodor\MessageQueue\Adapter\Testing\MessageBankFactory;
+use Hodor\MessageQueue\Consumer;
+use Hodor\MessageQueue\ConsumerQueue;
+use Hodor\MessageQueue\Producer;
+use Hodor\MessageQueue\ProducerQueue;
+
+class TestingWorkerQueueFactory
+{
+    /**
+     * @var MessageBankFactory
+     */
+    private $message_bank_factory;
+
+    /**
+     * @var Database
+     */
+    private $database;
+
+    /**
+     * @var Consumer
+     */
+    private $consumer;
+
+    /**
+     * @var Producer
+     */
+    private $producer;
+
+    /**
+     * @var WorkerQueueFactory
+     */
+    private $worker_queue_factory;
+
+    public function __construct(TestingConfig $config)
+    {
+        $this->message_bank_factory = new MessageBankFactory();
+        $this->database = new Database();
+
+        $adapter_factory = new Factory($config, $this->message_bank_factory);
+        $dequeuer = new Dequeuer($this->database);
+
+        $this->consumer = new Consumer($adapter_factory);
+        $this->producer = new Producer($adapter_factory);
+        $this->worker_queue_factory = new WorkerQueueFactory(
+            $this->producer,
+            $this->consumer,
+            $dequeuer
+        );
+    }
+
+    /**
+     * @param string $queue_name
+     * @return MessageBank
+     */
+    public function getMessageBank($queue_name)
+    {
+        return $this->message_bank_factory->getMessageBank("worker-{$queue_name}");
+    }
+
+    /**
+     * @return Database
+     */
+    public function getDatabase()
+    {
+        return $this->database;
+    }
+
+    /**
+     * @param string $queue_name
+     * @return ConsumerQueue
+     */
+    public function getConsumerQueue($queue_name)
+    {
+        return $this->consumer->getQueue("worker-{$queue_name}");
+    }
+
+    /**
+     * @param string $queue_name
+     * @return ProducerQueue
+     */
+    public function getProducerQueue($queue_name)
+    {
+        return $this->producer->getQueue("worker-{$queue_name}");
+    }
+
+    /**
+     * @return WorkerQueueFactory
+     */
+    public function getWorkerQueueFactory()
+    {
+        return $this->worker_queue_factory;
+    }
+
+    /**
+     * @param string $queue_name
+     * @return WorkerQueue
+     */
+    public function getWorkerQueue($queue_name)
+    {
+        return $this->worker_queue_factory->getWorkerQueue($queue_name);
+    }
+}

--- a/tests/src/Hodor/JobQueue/WorkerQueueTest.php
+++ b/tests/src/Hodor/JobQueue/WorkerQueueTest.php
@@ -4,16 +4,12 @@ namespace Hodor\JobQueue;
 
 use Exception;
 use Hodor\Database\Adapter\Testing\Database;
-use Hodor\Database\Adapter\Testing\Dequeuer;
 use Hodor\Database\Exception\BufferedJobNotFoundException;
+use Hodor\JobQueue\TestUtil\TestingWorkerQueueFactory;
 use Hodor\MessageQueue\Adapter\Testing\Config as TestingConfig;
-use Hodor\MessageQueue\Adapter\Testing\Factory;
 use Hodor\MessageQueue\Adapter\Testing\MessageBank;
-use Hodor\MessageQueue\Adapter\Testing\MessageBankFactory;
-use Hodor\MessageQueue\Consumer;
 use Hodor\MessageQueue\ConsumerQueue;
 use Hodor\MessageQueue\IncomingMessage;
-use Hodor\MessageQueue\Producer;
 use Hodor\MessageQueue\ProducerQueue;
 use PHPUnit_Framework_TestCase;
 use UnexpectedValueException;
@@ -57,23 +53,17 @@ class WorkerQueueTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $message_bank_factory = new MessageBankFactory();
         $config = new TestingConfig([]);
         $config->addQueueConfig('worker-default-worker', ['workers_per_server' => 5]);
-        $message_bank_factory->setConfig($config);
-        $adapter_factory = new Factory($config, $message_bank_factory);
 
-        $consumer = new Consumer($adapter_factory);
-        $producer = new Producer($adapter_factory);
+        $testing_worker_queue_factory = new TestingWorkerQueueFactory($config);
 
-        $this->message_bank = $message_bank_factory->getMessageBank('worker-default-worker');
-        $this->consumer = $consumer->getQueue('worker-default-worker');
-        $this->producer = $producer->getQueue('worker-default-worker');
-        $this->database = new Database();
-
-        $dequeuer = new Dequeuer($this->database);
-        $this->worker_queue_factory = new WorkerQueueFactory($producer, $consumer, $dequeuer);
-
+        $this->message_bank = $testing_worker_queue_factory->getMessageBank('default-worker');
+        $this->consumer = $testing_worker_queue_factory->getConsumerQueue('default-worker');
+        $this->producer = $testing_worker_queue_factory->getProducerQueue('default-worker');
+        $this->message_bank = $testing_worker_queue_factory->getMessageBank('default-worker');
+        $this->database = $testing_worker_queue_factory->getDatabase();
+        $this->worker_queue_factory = $testing_worker_queue_factory->getWorkerQueueFactory();
         $this->worker_queue = $this->worker_queue_factory->getWorkerQueue('default-worker');
     }
 


### PR DESCRIPTION
Previously QueueFactory and Queue objects were being
used, but those are deprecated in favor of the separate
Producer and Consumer classes
