### PR TITLE
Use Producer/Consumer Queue for BufferQueue

### DIFF
--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -89,7 +89,8 @@ class QueueManager
         }
 
         $this->buffer_queues[$queue_name] = new BufferQueue(
-            $this->getMessageQueue("bufferer-{$queue_name}"),
+            $this->getMqProducer()->getQueue("bufferer-{$queue_name}"),
+            $this->getMqConsumer()->getQueue("bufferer-{$queue_name}"),
             $this->getDatabase()->getBufferWorker(),
             $this->config
         );
@@ -134,17 +135,17 @@ class QueueManager
 
     public function beginBatch()
     {
-        $this->getMessageQueueFactory()->beginBatch();
+        $this->getMqProducer()->beginBatch();
     }
 
     public function publishBatch()
     {
-        $this->getMessageQueueFactory()->publishBatch();
+        $this->getMqProducer()->publishBatch();
     }
 
     public function discardBatch()
     {
-        $this->getMessageQueueFactory()->discardBatch();
+        $this->getMqProducer()->discardBatch();
     }
 
     /**
@@ -162,15 +163,6 @@ class QueueManager
         $this->database = $db_adapter_factory->getAdapter($config);
 
         return $this->database;
-    }
-
-    /**
-     * @param  string $queue_name
-     * @return MessageQueue
-     */
-    private function getMessageQueue($queue_name)
-    {
-        return $this->getMessageQueueFactory()->getQueue($queue_name);
     }
 
     /**

--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -164,6 +164,9 @@ class QueueManager
         return $this->database;
     }
 
+    /**
+     * @return Producer
+     */
     private function getMqProducer()
     {
         if ($this->mq_producer) {

--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -8,7 +8,6 @@ use Hodor\MessageQueue\Adapter\FactoryInterface as MqFactoryInterface;
 use Hodor\MessageQueue\AdapterFactory;
 use Hodor\MessageQueue\Consumer;
 use Hodor\MessageQueue\Producer;
-use Hodor\MessageQueue\Queue as MessageQueue;
 use Hodor\MessageQueue\QueueFactory as MqFactory;
 
 class QueueManager
@@ -163,22 +162,6 @@ class QueueManager
         $this->database = $db_adapter_factory->getAdapter($config);
 
         return $this->database;
-    }
-
-    /**
-     * @return MqFactory
-     */
-    private function getMessageQueueFactory()
-    {
-        if ($this->mq_factory) {
-            return $this->mq_factory;
-        }
-
-        $mq_adapter_factory = new AdapterFactory();
-        $mq_adapter = $mq_adapter_factory->getAdapter($this->config->getMessageQueueConfig());
-        $this->mq_factory = new MqFactory($mq_adapter);
-
-        return $this->mq_factory;
     }
 
     private function getMqProducer()


### PR DESCRIPTION
Rather than using the QueueFactory and Mq\Queue objects
to produce and consume messages, use the ProducerQueue
and ConsumerQueue objects.
