### PR TITLE
Create BufferQueueFactory

### DIFF
--- a/src/Hodor/JobQueue/BufferQueueFactory.php
+++ b/src/Hodor/JobQueue/BufferQueueFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Hodor\JobQueue;
+
+use Hodor\Database\Adapter\BufferWorkerInterface as Database;
+use Hodor\MessageQueue\Consumer;
+use Hodor\MessageQueue\Producer;
+
+/**
+ * @method BufferQueue getQueue(string $queue_name)
+ */
+class BufferQueueFactory extends AbstractQueueFactory
+{
+    /**
+     * @var Database
+     */
+    private $database;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @param Producer $producer
+     * @param Consumer $consumer
+     * @param Database $database
+     * @param Config $config
+     */
+    public function __construct(Producer $producer, Consumer $consumer, Database $database, Config $config)
+    {
+        parent::__construct($producer, $consumer);
+
+        $this->database = $database;
+        $this->config = $config;
+    }
+
+    /**
+     * @param string $queue_name
+     * @return BufferQueue
+     */
+    protected function generateQueue($queue_name)
+    {
+        return new BufferQueue(
+            $this->getProducer()->getQueue("bufferer-{$queue_name}"),
+            $this->getConsumer()->getQueue("bufferer-{$queue_name}"),
+            $this->database,
+            $this->config
+        );
+    }
+}

--- a/tests/src/Hodor/JobQueue/BufferQueueTest.php
+++ b/tests/src/Hodor/JobQueue/BufferQueueTest.php
@@ -28,6 +28,11 @@ class BufferQueueTest extends PHPUnit_Framework_TestCase
     private $consumer;
 
     /**
+     * @var BufferQueueFactory
+     */
+    private $buffer_queue_factory;
+
+    /**
      * @var BufferQueue
      */
     private $buffer_queue;
@@ -49,13 +54,16 @@ class BufferQueueTest extends PHPUnit_Framework_TestCase
         $this->message_bank = $test_util->getMessageBank('bufferer-test-queue');
         $this->consumer = $test_util->getConsumerQueue('bufferer-test-queue');
         $this->database = $test_util->getDatabase();
-        $this->buffer_queue = $test_util->getBufferQueue('test-queue');
+        $this->buffer_queue_factory = $test_util->getBufferQueueFactory();
+        $this->buffer_queue = $this->buffer_queue_factory->getQueue('test-queue');
     }
 
     /**
      * @covers ::__construct
      * @covers ::push
      * @covers ::<private>
+     * @covers \Hodor\JobQueue\AbstractQueueFactory
+     * @covers \Hodor\JobQueue\BufferQueueFactory
      */
     public function testJobCanBeBufferQueued()
     {
@@ -74,6 +82,8 @@ class BufferQueueTest extends PHPUnit_Framework_TestCase
      * @covers ::__construct
      * @covers ::push
      * @covers ::<private>
+     * @covers \Hodor\JobQueue\AbstractQueueFactory
+     * @covers \Hodor\JobQueue\BufferQueueFactory
      */
     public function testMultipleJobsCanBeBufferQueued()
     {
@@ -101,6 +111,8 @@ class BufferQueueTest extends PHPUnit_Framework_TestCase
      * @covers ::__construct
      * @covers ::push
      * @covers ::<private>
+     * @covers \Hodor\JobQueue\AbstractQueueFactory
+     * @covers \Hodor\JobQueue\BufferQueueFactory
      * @expectedException Exception
      */
     public function testBufferedJobOptionsAreValidated()
@@ -112,6 +124,8 @@ class BufferQueueTest extends PHPUnit_Framework_TestCase
      * @covers ::__construct
      * @covers ::push
      * @covers ::<private>
+     * @covers \Hodor\JobQueue\AbstractQueueFactory
+     * @covers \Hodor\JobQueue\BufferQueueFactory
      */
     public function testRunAfterIsConvertedToStringIfProvided()
     {
@@ -133,6 +147,8 @@ class BufferQueueTest extends PHPUnit_Framework_TestCase
      * @covers ::__construct
      * @covers ::processBuffer
      * @covers ::<private>
+     * @covers \Hodor\JobQueue\AbstractQueueFactory
+     * @covers \Hodor\JobQueue\BufferQueueFactory
      */
     public function testProcessingBufferedMessageMovesMessageToDatabase()
     {
@@ -168,6 +184,8 @@ class BufferQueueTest extends PHPUnit_Framework_TestCase
      * @covers ::__construct
      * @covers ::processBuffer
      * @covers ::<private>
+     * @covers \Hodor\JobQueue\AbstractQueueFactory
+     * @covers \Hodor\JobQueue\BufferQueueFactory
      * @expectedException Exception
      */
     public function testProcessingBufferedMessageAcknowledgesMessage()


### PR DESCRIPTION
Rather than tracking buffer queues in the queue manager,
track them in a BufferQueueFactory.  We might be able to
phase out the QueueManager since much of the buffer queue
functionality is now encapsulated in the BufferQueueFactory.