### PR TITLE
Remove buffer queue methods to BufferQueueFactory

### DIFF
--- a/bin/buffer-worker.php
+++ b/bin/buffer-worker.php
@@ -13,6 +13,6 @@ $queue_name = $args->getQueueName();
 
 $config = Config::loadFromFile($config_file);
 $queue_manager = new QueueManager($config);
-$buffer_worker = $queue_manager->getBufferQueue($queue_name);
+$buffer_worker = $queue_manager->getBufferQueueFactory()->getQueue($queue_name);
 
 $buffer_worker->processBuffer();

--- a/src/Hodor/JobQueue/BufferQueueFactory.php
+++ b/src/Hodor/JobQueue/BufferQueueFactory.php
@@ -36,6 +36,23 @@ class BufferQueueFactory extends AbstractQueueFactory
     }
 
     /**
+     * @param  string $name
+     * @param  array  $params
+     * @param  array  $options
+     * @return BufferQueue
+     */
+    public function getBufferQueueForJob($name, array $params, array $options)
+    {
+        $queue_name = $this->config->getJobQueueConfig()->getBufferQueueName(
+            $name,
+            $params,
+            $options
+        );
+
+        return $this->getQueue($queue_name);
+    }
+
+    /**
      * @param string $queue_name
      * @return BufferQueue
      */

--- a/src/Hodor/JobQueue/JobQueue.php
+++ b/src/Hodor/JobQueue/JobQueue.php
@@ -29,7 +29,7 @@ class JobQueue
      */
     public function push($job_name, array $params = [], array $options = [])
     {
-        $buffer_queue = $this->getQueueManager()->getBufferQueueForJob(
+        $buffer_queue = $this->getQueueManager()->getBufferQueueFactory()->getBufferQueueForJob(
             $job_name,
             $params,
             $options
@@ -44,17 +44,17 @@ class JobQueue
 
     public function beginBatch()
     {
-        $this->getQueueManager()->beginBatch();
+        $this->getQueueManager()->getBufferQueueFactory()->beginBatch();
     }
 
     public function publishBatch()
     {
-        $this->getQueueManager()->publishBatch();
+        $this->getQueueManager()->getBufferQueueFactory()->publishBatch();
     }
 
     public function discardBatch()
     {
-        $this->getQueueManager()->discardBatch();
+        $this->getQueueManager()->getBufferQueueFactory()->discardBatch();
     }
 
     /**

--- a/src/Hodor/JobQueue/QueueManager.php
+++ b/src/Hodor/JobQueue/QueueManager.php
@@ -62,32 +62,6 @@ class QueueManager
     }
 
     /**
-     * @param  string $queue_name
-     * @return BufferQueue
-     */
-    public function getBufferQueue($queue_name)
-    {
-        return $this->getBufferQueueFactory()->getQueue($queue_name);
-    }
-
-    /**
-     * @param  string $name
-     * @param  array  $params
-     * @param  array  $options
-     * @return BufferQueue
-     */
-    public function getBufferQueueForJob($name, array $params, array $options)
-    {
-        $queue_name = $this->config->getJobQueueConfig()->getBufferQueueName(
-            $name,
-            $params,
-            $options
-        );
-
-        return $this->getBufferQueue($queue_name);
-    }
-
-    /**
      * @return WorkerQueueFactory
      */
     public function getWorkerQueueFactory()
@@ -122,21 +96,6 @@ class QueueManager
         );
 
         return $this->buffer_queue_factory;
-    }
-
-    public function beginBatch()
-    {
-        $this->getBufferQueueFactory()->beginBatch();
-    }
-
-    public function publishBatch()
-    {
-        $this->getBufferQueueFactory()->publishBatch();
-    }
-
-    public function discardBatch()
-    {
-        $this->getBufferQueueFactory()->discardBatch();
     }
 
     /**


### PR DESCRIPTION
- Previously there was not a better place than QueueManager
  for the getBufferQueueForJob() method, but now we have a
  factory for BufferQueues.  Since getBufferQueueForJob() is
  basically generating buffer queues using a different set of
  criteria, it makes since for it to be in the BufferQueueFactory
- Remove batch management methods from QueueManager and have
  the JobQueue class access the BufferQueueFactory's batch
  management methods directly.  This way there is no confusion as
  to what queues the QueueManager's batch management methods would
  be managing.