### PR TITLE
Deprecate JobQueueFacade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Breaking Changes:
 
  - Upgraded Hodor's dependency on lightster/yo-pdo to v0.1.3+ from v0.0.2+
+ - Deprecated \Hodor\JobQueueFacade and will remove in 0.3.0
 
 Bug Fixes:
 

--- a/src/Hodor/JobQueueFacade.php
+++ b/src/Hodor/JobQueueFacade.php
@@ -4,6 +4,10 @@ namespace Hodor;
 
 use Hodor\JobQueue\JobQueue;
 
+/**
+ * @deprecated 0.3.0 Use Hodor\JobQueue\JobQueue with dependency injection
+ * @see \Hodor\JobQueue\JobQueue
+ */
 class JobQueueFacade
 {
     /**


### PR DESCRIPTION
\Hodor\JobQueue\JobQueue should be used instead, as the
README shows.