### PR TITLE
Explicitly name sequence and primary key names

### DIFF
--- a/migrations/postgres/20151022112749_CreateInitialSchema.php
+++ b/migrations/postgres/20151022112749_CreateInitialSchema.php
@@ -12,9 +12,14 @@ class CreateInitialSchema extends Migration
     protected function transactionalUp(YoPdo $yo_pdo)
     {
         $sql = <<<SQL
+CREATE SEQUENCE buffered_jobs_buffered_job_id_seq;
+CREATE SEQUENCE failed_jobs_failed_job_id_seq;
+CREATE SEQUENCE queued_jobs_queued_job_id_seq;
+CREATE SEQUENCE successful_jobs_successful_job_id_seq;
+
 CREATE TABLE buffered_jobs
 (
-    buffered_job_id SERIAL PRIMARY KEY,
+    buffered_job_id INT NOT NULL DEFAULT nextval('buffered_jobs_buffered_job_id_seq'::regclass),
     queue_name VARCHAR NOT NULL,
     job_name VARCHAR NOT NULL,
     job_params JSON NOT NULL,
@@ -28,7 +33,7 @@ CREATE TABLE buffered_jobs
 
 CREATE TABLE queued_jobs
 (
-    queued_job_id SERIAL PRIMARY KEY,
+    queued_job_id INT NOT NULL DEFAULT nextval('queued_jobs_queued_job_id_seq'::regclass),
     buffered_job_id INT NOT NULL UNIQUE,
     queue_name VARCHAR NOT NULL,
     job_name VARCHAR NOT NULL,
@@ -45,7 +50,7 @@ CREATE TABLE queued_jobs
 
 CREATE TABLE successful_jobs
 (
-    successful_job_id SERIAL PRIMARY KEY,
+    successful_job_id INT NOT NULL DEFAULT nextval('successful_jobs_successful_job_id_seq'::regclass),
     buffered_job_id INT NOT NULL UNIQUE,
     queue_name VARCHAR NOT NULL,
     job_name VARCHAR NOT NULL,
@@ -67,7 +72,7 @@ CREATE TABLE successful_jobs
 
 CREATE TABLE failed_jobs
 (
-    failed_job_id SERIAL PRIMARY KEY,
+    failed_job_id INT NOT NULL DEFAULT nextval('failed_jobs_failed_job_id_seq'::regclass),
     buffered_job_id INT NOT NULL UNIQUE,
     queue_name VARCHAR NOT NULL,
     job_name VARCHAR NOT NULL,
@@ -86,6 +91,11 @@ CREATE TABLE failed_jobs
     dequeued_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     dequeued_from VARCHAR NOT NULL
 );
+
+ALTER TABLE buffered_jobs ADD CONSTRAINT buffered_jobs_pkey PRIMARY KEY (buffered_job_id);
+ALTER TABLE queued_jobs ADD CONSTRAINT queued_jobs_pkey PRIMARY KEY (queued_job_id);
+ALTER TABLE successful_jobs ADD CONSTRAINT successful_jobs_pkey PRIMARY KEY (successful_job_id);
+ALTER TABLE failed_jobs ADD CONSTRAINT failed_jobs_pkey PRIMARY KEY (failed_job_id);
 SQL;
 
         $yo_pdo->queryMultiple($sql);
@@ -102,6 +112,11 @@ DROP TABLE buffered_jobs;
 DROP TABLE queued_jobs;
 DROP TABLE successful_jobs;
 DROP TABLE failed_jobs;
+
+DROP SEQUENCE IF EXISTS buffered_jobs_buffered_job_id_seq;
+DROP SEQUENCE IF EXISTS failed_jobs_failed_job_id_seq;
+DROP SEQUENCE IF EXISTS queued_jobs_queued_job_id_seq;
+DROP SEQUENCE IF EXISTS successful_jobs_successful_job_id_seq;
 SQL;
 
         $yo_pdo->queryMultiple($sql);


### PR DESCRIPTION
In rare circumstances (when someone has been messing with the DB ;P ),
the inferred sequence table and primary key names are appended with
numbers.  We can avoid numbers being appended by explicitly providing
the sequence table and primary key names.

Issue #85