### PR TITLE
Cache composer dependencies via .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,7 @@ notifications:
     on_success: change
     on_failure: always
     on_start:   change
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files


### PR DESCRIPTION
This will speed up the Travis CI builds a bit