### PR TITLE
Move scheduled jobs to a separate table

### DIFF
--- a/migrations/postgres/20170501024010_AddScheduledJobsTable.php
+++ b/migrations/postgres/20170501024010_AddScheduledJobsTable.php
@@ -1,0 +1,101 @@
+<?php
+
+use Hodor\Database\Phpmig\Migration;
+use Lstr\YoPdo\YoPdo;
+
+class AddScheduledJobsTable extends Migration
+{
+    /**
+     * @param YoPdo $yo_pdo
+     * @return void
+     */
+    protected function transactionalUp(YoPdo $yo_pdo)
+    {
+        $sql = <<<SQL
+CREATE TABLE scheduled_jobs
+(
+    buffered_job_id INT NOT NULL DEFAULT nextval('buffered_jobs_buffered_job_id_seq'::regclass),
+    queue_name VARCHAR NOT NULL,
+    job_name VARCHAR NOT NULL,
+    job_params JSON NOT NULL,
+    job_rank INT NOT NULL DEFAULT 5,
+    run_after TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    buffered_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    buffered_from VARCHAR NOT NULL,
+    mutex_id VARCHAR NOT NULL DEFAULT 'hodor:' || currval('buffered_jobs_buffered_job_id_seq'::regclass),
+    scheduled_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    scheduled_from VARCHAR NOT NULL
+);
+
+ALTER TABLE scheduled_jobs ADD CONSTRAINT scheduled_jobs_pkey PRIMARY KEY (buffered_job_id);
+CREATE INDEX scheduled_jobs_run_after ON scheduled_jobs (run_after DESC);
+
+ALTER TABLE buffered_jobs
+    ADD COLUMN scheduled_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN scheduled_from VARCHAR;
+ALTER TABLE queued_jobs
+    ADD COLUMN scheduled_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN scheduled_from VARCHAR;
+ALTER TABLE successful_jobs
+    ADD COLUMN scheduled_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN scheduled_from VARCHAR;
+ALTER TABLE failed_jobs
+    ADD COLUMN scheduled_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN scheduled_from VARCHAR;
+
+UPDATE buffered_jobs SET scheduled_at = inserted_at, scheduled_from = inserted_from;
+UPDATE queued_jobs SET scheduled_at = inserted_at, scheduled_from = inserted_from;
+UPDATE successful_jobs SET scheduled_at = inserted_at, scheduled_from = inserted_from;
+UPDATE failed_jobs SET scheduled_at = inserted_at, scheduled_from = inserted_from;
+
+ALTER TABLE buffered_jobs
+    ALTER COLUMN scheduled_at SET DEFAULT NOW(),
+    ALTER COLUMN scheduled_at SET NOT NULL,
+    ALTER COLUMN scheduled_from SET DEFAULT 'n/a',
+    ALTER COLUMN scheduled_from SET NOT NULL;
+ALTER TABLE queued_jobs
+    ALTER COLUMN scheduled_at SET DEFAULT NOW(),
+    ALTER COLUMN scheduled_at SET NOT NULL,
+    ALTER COLUMN scheduled_from SET DEFAULT 'n/a',
+    ALTER COLUMN scheduled_from SET NOT NULL;
+ALTER TABLE successful_jobs
+    ALTER COLUMN scheduled_at SET DEFAULT NOW(),
+    ALTER COLUMN scheduled_at SET NOT NULL,
+    ALTER COLUMN scheduled_from SET DEFAULT 'n/a',
+    ALTER COLUMN scheduled_from SET NOT NULL;
+ALTER TABLE failed_jobs
+    ALTER COLUMN scheduled_at SET DEFAULT NOW(),
+    ALTER COLUMN scheduled_at SET NOT NULL,
+    ALTER COLUMN scheduled_from SET DEFAULT 'n/a',
+    ALTER COLUMN scheduled_from SET NOT NULL;
+SQL;
+
+        $yo_pdo->queryMultiple($sql);
+    }
+
+    /**
+     * @param YoPdo $yo_pdo
+     * @return void
+     */
+    protected function transactionalDown(YoPdo $yo_pdo)
+    {
+        $sql = <<<SQL
+ALTER TABLE buffered_jobs
+    DROP COLUMN scheduled_at,
+    DROP COLUMN scheduled_from;
+ALTER TABLE queued_jobs
+    DROP COLUMN scheduled_at,
+    DROP COLUMN scheduled_from;
+ALTER TABLE successful_jobs
+    DROP COLUMN scheduled_at,
+    DROP COLUMN scheduled_from;
+ALTER TABLE failed_jobs
+    DROP COLUMN scheduled_at,
+    DROP COLUMN scheduled_from;
+
+DROP TABLE scheduled_jobs;
+SQL;
+
+        $yo_pdo->queryMultiple($sql);
+    }
+}

--- a/src/Hodor/Database/Adapter/Postgres/Superqueuer.php
+++ b/src/Hodor/Database/Adapter/Postgres/Superqueuer.php
@@ -47,6 +47,8 @@ class Superqueuer implements SuperqueuerInterface
      */
     public function getJobsToRunGenerator()
     {
+        $this->processScheduledJobs();
+
         $sql = <<<SQL
 WITH mutexed_buffered_jobs AS (
     SELECT DISTINCT ON (mutex_id)
@@ -119,6 +121,51 @@ SQL;
     public function publishBatch()
     {
         $this->getYoPdo()->transaction()->accept('superqueue-jobs');
+    }
+
+    private function processScheduledJobs()
+    {
+        $sql = <<<SQL
+INSERT INTO buffered_jobs
+(
+    buffered_job_id,
+    queue_name,
+    job_name,
+    job_params,
+    job_rank,
+    run_after,
+    buffered_at,
+    buffered_from,
+    inserted_at,
+    inserted_from,
+    mutex_id,
+    scheduled_at,
+    scheduled_from
+)
+SELECT
+    buffered_job_id,
+    queue_name,
+    job_name,
+    job_params,
+    job_rank,
+    run_after,
+    buffered_at,
+    buffered_from,
+    NOW(),
+    :inserted_from,
+    mutex_id,
+    scheduled_at,
+    scheduled_from
+FROM scheduled_jobs
+WHERE run_after <= NOW();
+
+DELETE FROM scheduled_jobs
+WHERE run_after <= NOW();
+SQL;
+
+        $this->getYoPdo()->transaction()->begin('scheduled-jobs');
+        $this->getYoPdo()->queryMultiple($sql, ['inserted_from' => gethostname()]);
+        $this->getYoPdo()->transaction()->accept('scheduled-jobs');
     }
 
     /**

--- a/src/Hodor/Database/Adapter/Postgres/Superqueuer.php
+++ b/src/Hodor/Database/Adapter/Postgres/Superqueuer.php
@@ -54,7 +54,6 @@ WITH mutexed_buffered_jobs AS (
     SELECT DISTINCT ON (mutex_id)
         buffered_jobs.*
     FROM buffered_jobs
-    WHERE run_after <= NOW()
     ORDER BY
         mutex_id,
         job_rank,

--- a/tests/src/Hodor/FlowTest.php
+++ b/tests/src/Hodor/FlowTest.php
@@ -60,13 +60,43 @@ class FlowTest extends PHPUnit_Framework_TestCase
             'the_time'    => date('c'),
             'known_value' => 'donuts',
             'job_options' => [
-                'run_after' => date('c'),
                 'job_rank' => 5,
             ],
         ];
 
         $this->queueJobs($job_name, [$job_params]);
 
+        $this->assertJobRan($job_name, $job_params);
+    }
+
+    public function testJobCanBeScheduled()
+    {
+        $job_name = 'job-name-' . uniqid();
+        $job_params = [
+            'the_time'    => date('c'),
+            'known_value' => 'donuts',
+            'job_options' => [
+                'job_rank' => 5,
+                'mutex_id' => 'chocolate',
+            ],
+        ];
+        $scheduled_job_params = [
+            'the_time'    => date('c'),
+            'known_value' => 'donuts',
+            'job_options' => [
+                'run_after' => date('c', time() + 2),
+                'job_rank' => 1,
+                'mutex_id' => 'chocolate',
+            ],
+        ];
+
+        $this->queueJobs($job_name, [$job_params, $job_params, $scheduled_job_params]);
+
+        $this->assertJobRan($job_name, $job_params);
+        sleep(3);
+        $this->runSuperqueuer();
+        $this->assertJobRan($job_name, $scheduled_job_params);
+        $this->runSuperqueuer();
         $this->assertJobRan($job_name, $job_params);
     }
 
@@ -93,7 +123,6 @@ class FlowTest extends PHPUnit_Framework_TestCase
             'the_time'    => date('c'),
             'known_value' => 'donuts',
             'job_options' => [
-                'run_after' => date('c'),
                 'job_rank' => 5,
             ],
         ];
@@ -160,7 +189,6 @@ class FlowTest extends PHPUnit_Framework_TestCase
             'the_time'    => date('c'),
             'known_value' => 'donuts',
             'job_options' => [
-                'run_after' => date('c'),
                 'job_rank' => 5,
             ],
         ];

--- a/tests/src/Hodor/FlowTest.php
+++ b/tests/src/Hodor/FlowTest.php
@@ -84,7 +84,7 @@ class FlowTest extends PHPUnit_Framework_TestCase
             'the_time'    => date('c'),
             'known_value' => 'donuts',
             'job_options' => [
-                'run_after' => date('c', time() + 2),
+                'run_after' => date('c', time() + 3),
                 'job_rank' => 1,
                 'mutex_id' => 'chocolate',
             ],
@@ -93,7 +93,7 @@ class FlowTest extends PHPUnit_Framework_TestCase
         $this->queueJobs($job_name, [$job_params, $job_params, $scheduled_job_params]);
 
         $this->assertJobRan($job_name, $job_params);
-        sleep(3);
+        sleep(5);
         $this->runSuperqueuer();
         $this->assertJobRan($job_name, $scheduled_job_params);
         $this->runSuperqueuer();


### PR DESCRIPTION
Separating the records makes it more efficient for postgres to use an
index on `run_after` to filter out upcoming jobs