### PR TITLE
Update tests to use configured host for RabbitMQ

### DIFF
--- a/tests/src/Hodor/FlowTest.php
+++ b/tests/src/Hodor/FlowTest.php
@@ -367,6 +367,7 @@ PHP;
         $dsn = $this->generateDsn($db_credentials);
 
         $config = $config_template;
+        $config['queue_defaults']['host'] = $config_credentials['test']['rabbitmq']['host'];
         $config['superqueue']['database'] = [
             'type'     => 'pgsql',
             'dsn'      => $dsn,

--- a/tests/src/Hodor/JobQueue/JobQueueTest.php
+++ b/tests/src/Hodor/JobQueue/JobQueueTest.php
@@ -139,7 +139,7 @@ class JobQueueTest extends PHPUnit_Framework_TestCase
             'superqueue' => ['database' => ['type' => 'testing']],
             'buffer_queues'   => [
                 'default' => [
-                    'host' => 'localhost',
+                    'host' => 'fake-host',
                     'username' => 'guest',
                     'password' => 'guest',
                     'bufferers_per_server' => 1,


### PR DESCRIPTION
The RabbitMQ host was being hard-coded to localhost for some tests,
which does not work when RabbitMQ is hosted on another host
(READ: docker container). Using the hostname listed in the test config
for these tests will allow the tests to work just like the tests that
already work with a separate RabbitMQ host.