### PR TITLE
Re-order travis.yml config options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ services:
 addons:
   postgresql: "9.3"
 
+install:
+  - composer install
+
 before_script:
   - psql -c 'create database travisci_hodor;' -U postgres
   - cp config/dist/config.test.php config/config.test.php
   - sed -i 's#dbname=test_hodor#dbname=travisci_hodor#' config/config.test.php
-
-install:
-  - composer install
 
 after_script:
   - vendor/bin/test-reporter --coverage-report=tests/log/coverage.xml


### PR DESCRIPTION
I want the config options to appear in the order they are used in the
build lifecycle. This will hopefully make it clearer that composer
dependencies have been installed before the config is setup.

https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle