### PR TITLE
Add command to setup testing config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ install:
 
 before_script:
   - psql -c 'create database travisci_hodor;' -U postgres
-  - cp config/dist/config.test.php config/config.test.php
-  - sed -i 's#dbname=test_hodor#dbname=travisci_hodor#' config/config.test.php
+  - make install-test-travis
 
 after_script:
   - vendor/bin/test-reporter --coverage-report=tests/log/coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,12 @@ test:
 
 install:
 	composer install
+
+install-test:
+	php bin/hodor.php test:generate-config
+
+install-test-travis:
+	php bin/hodor.php test:generate-config --postgres-dbname=travisci_hodor
+
+install-test-docker:
+	php bin/hodor.php test:generate-config --postgres-host=postgres --rabbitmq-host=rabbitmq

--- a/bin/hodor.php
+++ b/bin/hodor.php
@@ -4,6 +4,7 @@
 require_once __DIR__ . '/../bootstrap.php';
 
 use Hodor\Command\DatabaseMigrateCommand;
+use Hodor\Command\TestGenerateConfigCommand;
 use Symfony\Component\Console\Application as ConsoleApp;
 
 $app = require_once __DIR__ . '/../bootstrap.php';
@@ -16,6 +17,7 @@ $console = new ConsoleApp(
 
 $console->add(new DaemonGenerateConfigCommand());
 $console->add(new DatabaseMigrateCommand());
+$console->add(new TestGenerateConfigCommand());
 
 $exit_code = $console->run();
 

--- a/config/dist/config.test.php
+++ b/config/dist/config.test.php
@@ -3,13 +3,13 @@ return [
     'test' => [
         'db' => [
             'yo-pdo-pgsql' => [
-                'dsn'      => 'pgsql:host=localhost;dbname=test_hodor',
+                'dsn'      => "pgsql:host={$options['postgres-host']};dbname={$options['postgres-dbname']}",
                 'username' => 'postgres',
                 'password' => '',
             ],
         ],
         'rabbitmq' => [
-            'host'            => '127.0.0.1',
+            'host'            => $options['rabbitmq-host'],
             'port'            => 5672,
             'username'        => 'guest',
             'password'        => 'guest',

--- a/src/Hodor/Command/TestGenerateConfigCommand.php
+++ b/src/Hodor/Command/TestGenerateConfigCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Hodor\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TestGenerateConfigCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('test:generate-config')
+            ->setDescription('Generate a config file for tests')
+            ->addOption(
+                'config-file',
+                false,
+                InputOption::VALUE_REQUIRED,
+                'Config file to save the config to',
+                __DIR__ . '/../../../config/config.test.php'
+            )
+            ->addOption(
+                'postgres-host',
+                false,
+                InputOption::VALUE_REQUIRED,
+                'Host name to use for postgres',
+                'localhost'
+            )
+            ->addOption(
+                'postgres-dbname',
+                false,
+                InputOption::VALUE_REQUIRED,
+                'Database name to use for postgres',
+                'test_hodor'
+            )
+            ->addOption(
+                'rabbitmq-host',
+                false,
+                InputOption::VALUE_REQUIRED,
+                'Host name to use for rabbitmq',
+                '127.0.0.1'
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $options = [
+            'postgres-host'   => $input->getOption('postgres-host'),
+            'postgres-dbname' => $input->getOption('postgres-dbname'),
+            'rabbitmq-host'   => $input->getOption('rabbitmq-host'),
+        ];
+
+        $template = function (array $options) {
+            return require __DIR__ . '/../../../config/dist/config.test.php';
+        };
+        $config_contents = "<?php\nreturn " . var_export($template($options), true) . ";";
+
+        file_put_contents($input->getOption('config-file'), $config_contents);
+    }
+}


### PR DESCRIPTION
Travis env needs one config, docker dev env needs another config,
and other dev environments need other configs. Having a command allows
for the minor differences to be handled by changing the command line
options, thereby avoiding the need to duplicate large parts of a config
file.