### PR TITLE
Disable PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1


### PR DESCRIPTION
PHP 5.5 is out of its support lifecycle, and the Hodor tests are failing
on PHP 5.5, presumably because of the garbage collection bug that
php-amqplib suffered from in PHP 5.5.