### PR TITLE
Fix superqueuer exception when no jobs are queued

### DIFF
--- a/src/Hodor/JobQueue/Superqueue.php
+++ b/src/Hodor/JobQueue/Superqueue.php
@@ -88,6 +88,10 @@ class Superqueue
 
     private function publishBatch()
     {
+        if ($this->jobs_queued <= 0) {
+            return;
+        }
+
         // the database transaction needs to be committed before the
         // message is pushed to Rabbit MQ to prevent jobs from being
         // processed by workers before they have been moved to buffered_jobs

--- a/tests/src/Hodor/JobQueue/SuperqueueTest.php
+++ b/tests/src/Hodor/JobQueue/SuperqueueTest.php
@@ -60,6 +60,16 @@ class SuperqueueTest extends PHPUnit_Framework_TestCase
      * @covers ::queueJobsFromDatabaseToWorkerQueue
      * @covers ::<private>
      */
+    public function testEmptyBatchOfJobsCanBeQueued()
+    {
+        $this->assertJobsAreQueued(0);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::queueJobsFromDatabaseToWorkerQueue
+     * @covers ::<private>
+     */
     public function testPartialBatchOfJobsCanBeQueued()
     {
         $this->assertJobsAreQueued(2);


### PR DESCRIPTION
An exception was occurring because a DB transaction was being committed
when a transaction had not yet been started. The DB transaction is only
started if there are jobs to be queued.