### PR TITLE
Fix Docker 'empty continuation lines' warning

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,19 +1,20 @@
 FROM php:5.6.24-cli
 MAINTAINER Matt Light <matt.light@lightdatasys.com>
 
+# - bcmath is for phpunit
+# - pdo_pgsql is for postgres
+# - sockets is for phpamqplib
+# - zip is for composer
+
 RUN apt-get update -qq \
     && apt install -yqq \
         libpq-dev \
         git \
         postgresql-client \
     && docker-php-ext-install -j$(nproc) \
-        # for phpunit
         bcmath \
-        # for postgres
         pdo_pgsql \
-        # for phpamqplib
         sockets \
-        # for composer
         zip \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug


### PR DESCRIPTION
The following warnings are occurring:
```
[WARNING]: Empty continuation line found in:
    RUN apt-get update -qq     && apt install -yqq         libpq-dev         git         postgresql-client     && docker-php-ext-install -j$(nproc)         bcmath         pdo_pgsql         sockets         zip     && pecl install xdebug     && docker-php-ext-enable xdebug
[WARNING]: Empty continuation lines will become errors in a future release.
```

The warnings are caused by inline comments within a
Dockerfile `RUN` command