### PR TITLE
Maintain composer cache outside of container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       dockerfile: docker/php/Dockerfile
     volumes:
       - .:/hodor
-      - ~/.composer/:/.composer
+      - ~/.composer/:/root/.composer
     depends_on:
       - postgres
       - rabbitmq


### PR DESCRIPTION
The composer cache volume was mapped to the wrong directory on the
docker container, so the cache was being lost when the container was
destroyed.